### PR TITLE
Remove the different way of installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Run the following command in your command prompt
 pip install -U scratchattach
 ```
 
+If you're on macOS / Linux and the command doesn't work for you, try using `pip3` instead of `pip`.
+
 # Logging in  `scratch3.Session`
 
 **Logging in with username / password:**

--- a/README.md
+++ b/README.md
@@ -21,15 +21,6 @@ Run the following command in your command prompt
 pip install -U scratchattach
 ```
 
-**OR**
-
-Add this to your Python code:
-```python
-import os
-
-os.system("pip install -U scratchattach")
-```
-
 # Logging in  `scratch3.Session`
 
 **Logging in with username / password:**


### PR DESCRIPTION
It's bad practice, and really no one should be using it. If your users don't have the package, then tell them to install it and also add a requirements.txt file.