### PR TITLE
Add CI action to format code on push or PR

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -24,3 +24,12 @@ jobs:
         run: |
           python3 -m black .
           python3 -m isort .
+
+      - if: steps.changes.outputs.scratchattach == 'true'
+        name: 'Push formatted code'
+        run: |
+          git config --global user.name 'TimMcCool'
+          git config --global user.email 'TimMcCool@users.noreply.github.com'
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git commit -am "Code format"
+          git push

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,27 +1,28 @@
-name: auto-format
-on: [push, pull_request]
+
+
+name: Run tests
+
+on: [push]
+
 jobs:
-  format:
+  build:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps: 
+      - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v2
+        id: changes
         with:
-          ref: ${{ github.ref_name }}
+          filters: |
+            scratchattach:
+              - 'scratchattach/**'
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      
       - if: steps.changes.outputs.scratchattach == 'true'
-      - name: Install dependencies
+        name: did anything change
         run: |
-          pip install -U pip
-          pip install black isort
-      - if: steps.changes.outputs.scratchattach == 'true'
-      - name: Format codebase
-        run: |
-          python3 -m black .
-          python3 -m isort .
-      - if: steps.changes.outputs.scratchattach == 'true'
-      - name: Push changes back
-        run: |
-          git config --global user.name 'YOUR USERNAME'
-          git config --global user.email 'YOUR USERNAME@users.noreply.github.com'
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
-          git commit -am "Format codebase"
-          git push
+          echo things have changed

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,15 +1,10 @@
+name: Run formatting
 
-
-name: Run tests
-
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.8", "3.9", "3.10"]
     steps: 
       - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
@@ -18,11 +13,14 @@ jobs:
           filters: |
             scratchattach:
               - 'scratchattach/**'
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
       
       - if: steps.changes.outputs.scratchattach == 'true'
-        name: did anything change
+        name: Install requirements
         run: |
-          echo things have changed
+          python3 -m pip install black isort
+          
+      - if: steps.changes.outputs.scratchattach == 'true'
+        name: Do formatting
+        run: |
+          python3 -m black .
+          python3 -m isort .

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,33 @@
+name: auto-format
+on: [push, pull_request]
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            scratchattach:
+              - 'scratchattach/*'
+      - uses: actions/checkout@v1
+        with:
+          ref: ${{ github.ref_name }}
+      - if: steps.changes.outputs.scratchattach == 'true'
+        - name: Install dependencies
+          run: |
+            pip install -U pip
+            pip install black isort
+      - if: steps.changes.outputs.scratchattach == 'true'
+        - name: Format codebase
+          run: |
+            python3 -m black .
+            python3 -m isort .
+      - if: steps.changes.outputs.scratchattach == 'true'
+        - name: Push changes back
+          run: |
+            git config --global user.name 'YOUR USERNAME'
+            git config --global user.email 'YOUR USERNAME@users.noreply.github.com'
+            git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+            git commit -am "Format codebase"
+            git push

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -4,12 +4,6 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: dorny/paths-filter@v2
-        id: changes
-        with:
-          filters: |
-            scratchattach:
-              - 'scratchattach/*'
       - uses: actions/checkout@v1
         with:
           ref: ${{ github.ref_name }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -14,20 +14,20 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
       - if: steps.changes.outputs.scratchattach == 'true'
-        - name: Install dependencies
-          run: |
-            pip install -U pip
-            pip install black isort
+      - name: Install dependencies
+        run: |
+          pip install -U pip
+          pip install black isort
       - if: steps.changes.outputs.scratchattach == 'true'
-        - name: Format codebase
-          run: |
-            python3 -m black .
-            python3 -m isort .
+      - name: Format codebase
+        run: |
+          python3 -m black .
+          python3 -m isort .
       - if: steps.changes.outputs.scratchattach == 'true'
-        - name: Push changes back
-          run: |
-            git config --global user.name 'YOUR USERNAME'
-            git config --global user.email 'YOUR USERNAME@users.noreply.github.com'
-            git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
-            git commit -am "Format codebase"
-            git push
+      - name: Push changes back
+        run: |
+          git config --global user.name 'YOUR USERNAME'
+          git config --global user.email 'YOUR USERNAME@users.noreply.github.com'
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git commit -am "Format codebase"
+          git push

--- a/scratchattach/_project.py
+++ b/scratchattach/_project.py
@@ -10,7 +10,7 @@ headers = {
     'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36',
     "x-csrftoken": "a",
     "x-requested-with": "XMLHttpRequest",
-    "referer": "https://scratch.mit.edu",
+    "referer": "https://scratch.mit.edu"
 }
 
 class PartialProject:

--- a/setup.py
+++ b/setup.py
@@ -7,24 +7,25 @@ DESCRIPTION = 'An Scratch API Wrapper for scratch.mit.edu'
 LONG_DESCRIPTION = DESCRIPTION
 
 # Setting up
-setup(
-    name="scratchattach",
-    version=VERSION,
-    author="TimMcCool",
-    author_email="",
-    description=DESCRIPTION,
-    long_description_content_type="text/markdown",
-    long_description=open('README.md').read(),
-    packages=find_packages(),
-    install_requires=["websocket-client","numpy","requests"],
-    keywords=['scratch api', 'scratchattach', 'scratch api python', 'scratch python', 'scratch for python', 'scratch', 'scratch cloud', 'scratch cloud variables', 'scratch bot'],
-    url='https://github.com/TimMcCool/scratchattach',
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "Programming Language :: Python :: 3",
-        "Operating System :: Unix",
-        "Operating System :: MacOS :: MacOS X",
-        "Operating System :: Microsoft :: Windows",
-    ]
-)
+if __name__ == "__main__":
+    setup(
+        name="scratchattach",
+        version=VERSION,
+        author="TimMcCool",
+        author_email="",
+        description=DESCRIPTION,
+        long_description_content_type="text/markdown",
+        long_description=open('README.md').read(),
+        packages=find_packages(),
+        install_requires=["websocket-client","numpy","requests"],
+        keywords=['scratch api', 'scratchattach', 'scratch api python', 'scratch python', 'scratch for python', 'scratch', 'scratch cloud', 'scratch cloud variables', 'scratch bot'],
+        url='https://github.com/TimMcCool/scratchattach',
+        classifiers=[
+            "Development Status :: 5 - Production/Stable",
+            "Intended Audience :: Developers",
+            "Programming Language :: Python :: 3",
+            "Operating System :: Unix",
+            "Operating System :: MacOS :: MacOS X",
+            "Operating System :: Microsoft :: Windows",
+        ]
+    )


### PR DESCRIPTION
This would take other developers' poorly formatted Python code and format it to make it consistent with the entire codebase. [Black](https://black.readthedocs.io/) formats your general code and [Isort](https://isort.readthedocs.io/) structures imports to match proper style guides. 

Just remember to add a GitHub token to your repository secrets by going to [token settings](https://github.com/settings/tokens) and creating a classic token that you can copy and paste into a new secret.

Hopefully, this helps :) (sorry for 10 commits I had to do everything in the browser)