### PR TITLE
Improve studio and project functions

### DIFF
--- a/scratchattach/__init__.py
+++ b/scratchattach/__init__.py
@@ -10,26 +10,45 @@ from .encoder import *
 def get_news(*, limit=10, offset=0):
     return requests.get(f"https://api.scratch.mit.edu/news?limit={limit}&offset={offset}").json()
 
-def featured_projects():
-    return requests.get("https://api.scratch.mit.edu/proxy/featured").json()["community_featured_projects"]
+def featured_projects(json=False):
+    response = requests.get("https://api.scratch.mit.edu/proxy/featured").json()["community_featured_projects"]
+    if json:
+        return response
+    return [Project(**project) for project in response]
 
-def featured_studios():
-    return requests.get("https://api.scratch.mit.edu/proxy/featured").json()["community_featured_studios"]
+def featured_studios(json=False):
+    response = requests.get("https://api.scratch.mit.edu/proxy/featured").json()["community_featured_studios"]
+    if json:
+        return response
+    return [Studio(**studio) for studio in response]
 
-def top_loved():
-    return requests.get("https://api.scratch.mit.edu/proxy/featured").json()["community_most_loved_projects"]
+def top_loved(json=False):
+    response = requests.get("https://api.scratch.mit.edu/proxy/featured").json()["community_most_loved_projects"]
+    if json:
+        return response
+    return [Project(**project) for project in response]
 
-def top_remixed():
-    return requests.get("https://api.scratch.mit.edu/proxy/featured").json()["community_most_remixed_projects"]
+def top_remixed(json=False):
+    response = requests.get("https://api.scratch.mit.edu/proxy/featured").json()["community_most_remixed_projects"]
+    if json:
+        return response
+    return [Project(**project) for project in response]
 
-def newest_projects():
-    return requests.get("https://api.scratch.mit.edu/proxy/featured").json()["community_newest_projects"]
+def newest_projects(json=False):
+    response = requests.get("https://api.scratch.mit.edu/proxy/featured").json()["community_newest_projects"]
+    if json:
+        return response
+    return [Project(**project) for project in response]
 
-def curated_projects():
-    return requests.get("https://api.scratch.mit.edu/proxy/featured").json()["curator_top_projects"]
+def curated_projects(json=False):
+    response = requests.get("https://api.scratch.mit.edu/proxy/featured").json()["curator_top_projects"]
+    return [Project(**project) for project in response]
 
-def design_studio_projects():
-    return requests.get("https://api.scratch.mit.edu/proxy/featured").json()["scratch_design_studio"]
+def design_studio_projects(json=False):
+    response = requests.get("https://api.scratch.mit.edu/proxy/featured").json()["scratch_design_studio"]
+    if json:
+        return response
+    return [Project(**project) for project in response]
 
 def search_posts(*, query, order="newest", page=0):
     try:

--- a/scratchattach/project.py
+++ b/scratchattach/project.py
@@ -149,7 +149,12 @@ class Project(PartialProject):
     '''
 
     def __str__(self):
-        return self.title
+        author = getattr(self, "author", None)
+        return self.title + (f" by {author}" if author else "") + f" ({self.id})"
+
+    def __repr__(self):
+        author = getattr(self, "author", None)
+        return self.title + (f" by {author}" if author else "") + f" ({self.id})"
 
     def update(self):
         """

--- a/scratchattach/studio.py
+++ b/scratchattach/studio.py
@@ -66,6 +66,12 @@ class Studio:
         self._json_headers["accept"] = "application/json"
         self._json_headers["Content-Type"] = "application/json"
 
+    def __str__(self):
+        return f"{self.title} ({self.id})"
+
+    def __repr__(self):
+        return f"{self.title} ({self.id})"
+
     def update(self):
         """
         Updates the attributes of the Studio object
@@ -491,8 +497,14 @@ def get_studio(studio_id):
     except Exception as e:
         raise(e)
 
-def search_studios(*, query="", mode="trending", language="en", limit=40, offset=0):
-    return requests.get(f"https://api.scratch.mit.edu/search/studios?limit={limit}&offset={offset}&language={language}&mode={mode}&q={query}").json()
+def search_studios(*, query="", mode="trending", language="en", limit=40, offset=0, json=False):
+    response = requests.get(f"https://api.scratch.mit.edu/search/studios?limit={limit}&offset={offset}&language={language}&mode={mode}&q={query}").json()
+    if json:
+        return response
+    return [Studio(**studio) for studio in response]
 
-def explore_studios(*, query="", mode="trending", language="en", limit=40, offset=0):
-    return requests.get(f"https://api.scratch.mit.edu/explore/studios?limit={limit}&offset={offset}&language={language}&mode={mode}&q={query}").json()
+def explore_studios(*, query="", mode="trending", language="en", limit=40, offset=0, json=False):
+    response = requests.get(f"https://api.scratch.mit.edu/explore/studios?limit={limit}&offset={offset}&language={language}&mode={mode}&q={query}").json()
+    if json:
+        return response
+    return [Studio(**studio) for studio in response]

--- a/scratchattach/user.py
+++ b/scratchattach/user.py
@@ -308,7 +308,7 @@ class User:
                 "x-requested-with": "XMLHttpRequest",
                 "Cookie": "scratchcsrftoken=a;scratchlanguage=en;",
                 "referer": "https://scratch.mit.edu",
-                'user-agent': 'Mozilla/f5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36',
+                'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36',
             }
         ).text
         text = text.split("Studios I Follow (")[1]

--- a/scratchattach/user.py
+++ b/scratchattach/user.py
@@ -103,9 +103,9 @@ class User:
         source = soup.find_all("li")
                 
         for data in source:
-                
+
             time=data.find('div').find('span').findNext().findNext().text.strip()
-                
+
             if '\xa0' in time:
                 while '\xa0' in time: time=time.replace('\xa0', ' ')
                 
@@ -308,7 +308,7 @@ class User:
                 "x-requested-with": "XMLHttpRequest",
                 "Cookie": "scratchcsrftoken=a;scratchlanguage=en;",
                 "referer": "https://scratch.mit.edu",
-                'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36',
+                'user-agent': 'Mozilla/f5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36',
             }
         ).text
         text = text.split("Studios I Follow (")[1]
@@ -316,7 +316,14 @@ class User:
         return int(text)
 
     def studios(self, *, limit=40, offset=0):
-        return requests.get(f"https://api.scratch.mit.edu/users/{self.username}/studios/curate?limit={limit}&offset={offset}").json()
+        """
+        Returns:
+            list<scratchattach.studio.Studio>: The user's curated studios
+        """
+        from . import Studio
+        
+        response = requests.get(f"https://api.scratch.mit.edu/users/{self.username}/studios/curate?limit={limit}&offset={offset}").json()
+        return [Studio(**studio) for studio in response]
 
     def projects(self, *, limit=None, offset=0):
         """


### PR DESCRIPTION
Currently, the functions for getting projects/studios on the frontpage and searching studios return JSON instead of objects. This PR adds support for returning studio and project objects from these functions. You will still need to call `x.update()` on the projects/studios you want to access, but this makes things convenient

For backwards compatibility, there's a `json` keyword param on the modified functions to return the plain JSON

Also, Project and Studio objects now have better `__str__` and `__repr__` methods. Example:
```
[Linux Mint 21.3 concept (938495273), Computer Screensaver (936911761), Music maker (938935000), Virus PC (931443038), ...]
```