### PR TITLE
Unlimited api request functions (REPLACEMENT for #188)

### DIFF
--- a/scratchattach/commons.py
+++ b/scratchattach/commons.py
@@ -15,7 +15,7 @@ def api_iterative_data(fetch_func, limit, offset, max_req_limit=40, unpack=True)
     end = offset + limit
     api_data = []
     for offs in range(offset, end, max_req_limit):
-        # print(offs, max_req_limit)
+        print(offs, max_req_limit)
         d = fetch_func(
             offs, max_req_limit
         )  # Mimick actual scratch by only requesting the max amount
@@ -29,4 +29,17 @@ def api_iterative_data(fetch_func, limit, offset, max_req_limit=40, unpack=True)
             break
     api_data = api_data[:limit]
     assert len(api_data) <= limit
+    return api_data
+
+
+def api_iterative_simple(url, limit, offset, max_req_limit=40, add_params=""):
+    def fetch(o, l):
+        resp = requests.get(f"{url}?limit={l}&offset={o}{add_params}").json()
+        if not resp or resp == {"code": "BadRequest", "message": ""}:
+            return None
+        return resp
+
+    api_data = api_iterative_data(
+        fetch, limit, offset, max_req_limit=max_req_limit, unpack=True
+    )
     return api_data

--- a/scratchattach/commons.py
+++ b/scratchattach/commons.py
@@ -1,0 +1,32 @@
+"""Common functions used by various internal modules"""
+
+import requests
+
+
+def api_iterative_data(fetch_func, limit, offset, max_req_limit=40, unpack=True):
+    """
+    Iteratively gets data by calling fetch_func with a moving offset and a limit.
+    Once fetch_func returns None, the retrieval is completed.
+    """
+    if limit is None:
+        limit = max_req_limit
+    assert offset >= 0
+    assert limit >= 0
+    end = offset + limit
+    api_data = []
+    for offs in range(offset, end, max_req_limit):
+        # print(offs, max_req_limit)
+        d = fetch_func(
+            offs, max_req_limit
+        )  # Mimick actual scratch by only requesting the max amount
+        if d is None:
+            break
+        if unpack:
+            api_data.extend(d)
+        else:
+            api_data.append(d)
+        if len(d) < max_req_limit:
+            break
+    api_data = api_data[:limit]
+    assert len(api_data) <= limit
+    return api_data

--- a/scratchattach/commons.py
+++ b/scratchattach/commons.py
@@ -40,11 +40,11 @@ def api_iterative_data(fetch_func, limit, offset, max_req_limit=40, unpack=True)
 
 
 def api_iterative_simple(
-    url, limit, offset, max_req_limit=40, add_params="", headers=headers
+    url, limit, offset, max_req_limit=40, add_params="", headers=headers, cookies={}
 ):
     def fetch(o, l):
         resp = requests.get(
-            f"{url}?limit={l}&offset={o}{add_params}", headers=headers
+            f"{url}?limit={l}&offset={o}{add_params}", headers=headers, cookies=cookies
         ).json()
         if not resp or resp == {"code": "BadRequest", "message": ""}:
             return None

--- a/scratchattach/commons.py
+++ b/scratchattach/commons.py
@@ -2,6 +2,13 @@
 
 import requests
 
+headers = {
+    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36",
+    "x-csrftoken": "a",
+    "x-requested-with": "XMLHttpRequest",
+    "referer": "https://scratch.mit.edu",
+}
+
 
 def api_iterative_data(fetch_func, limit, offset, max_req_limit=40, unpack=True):
     """
@@ -32,9 +39,13 @@ def api_iterative_data(fetch_func, limit, offset, max_req_limit=40, unpack=True)
     return api_data
 
 
-def api_iterative_simple(url, limit, offset, max_req_limit=40, add_params=""):
+def api_iterative_simple(
+    url, limit, offset, max_req_limit=40, add_params="", headers=headers
+):
     def fetch(o, l):
-        resp = requests.get(f"{url}?limit={l}&offset={o}{add_params}").json()
+        resp = requests.get(
+            f"{url}?limit={l}&offset={o}{add_params}", headers=headers
+        ).json()
         if not resp or resp == {"code": "BadRequest", "message": ""}:
             return None
         return resp

--- a/scratchattach/exceptions.py
+++ b/scratchattach/exceptions.py
@@ -3,56 +3,72 @@ class Unauthenticated(Exception):
     Raised when an action that requires a log in / session is performed on an object that wasn't created with a session.
 
     Example: If the :meth:`scratchattach.project.Project.love` function is called on a Project object created with :meth:`scratchattach.project.get_project`, it will raise this error.
-    
+
     If Project / Studio / User objects are created using :meth:`scratchattach.get_project` / :meth:`scratchattach.get_studio` / :meth:`scratchattach.get_user`, they can't be used to perform action that require a session. Use :meth:`scratchattach.Session.connect_project` / :meth:`scratchattach.Session.connect_user` / :meth:`scratchattach.Session.connect_studio` instead.
     """
+
     def __init__(self, message=""):
         self.message = "You can't perform this action because you're not logged in. The object on which the method was called wasn't created with a session. More information: https://scratchattach.readthedocs.io/en/latest/scratchattach.html#scratchattach.exceptions.Unauthenticated"
         super().__init__(self.message)
+
     pass
+
 
 class Unauthorized(Exception):
     """
     Raised when an action is performed that the user associated with the session that the object was created with is not allowed to do.
-    
+
     Example: Changing the "about me" of other users will raise this error.
     """
+
     def __init__(self, message=""):
         self.message = "You are not authorized to perform this action."
         super().__init__(self.message)
+
     pass
+
 
 class UserNotFound(Exception):
     """
     Raised when a non-existent user is requested.
     """
+
     pass
+
 
 class ProjectNotFound(Exception):
     """
     Raised when a non-existent project is requested.
     """
+
     pass
+
 
 class StudioNotFound(Exception):
     """
     Raised when a non-existent studio is requested.
     """
+
     pass
+
 
 class ConnectionError(Exception):
     """
     Raised when connecting to Scratch's cloud server fails. This can have various reasons.
     """
+
     pass
+
 
 class XTokenError(Exception):
     """
     Raised when an action can't be performed because there is no XToken available.
-     
+
     This error can occur if the xtoken couldn't be fetched when the session was created. Some actions (like loving projects) require providing this token.
     """
+
     pass
+
 
 class LoginFailure(Exception):
     """
@@ -60,46 +76,61 @@ class LoginFailure(Exception):
 
     This could be caused by an invalid username / password. Another cause could be that your IP address was banned from logging in to Scratch. If you're using an online IDE (like replit), try running the code on your computer.
     """
+
     pass
+
 
 class InvalidCloudValue(Exception):
     """
     Raised when a cloud variable is set to an invalid value.
     """
+
     pass
+
 
 class FetchError(Exception):
     """
-    Raised when getting information from the Scratch API fails. This can have various reasons. Make sure all provided arguments are valid. If you provided an "offset" keyword argument, its value shouldn't exceed 40.
+    Raised when getting information from the Scratch API fails. This can have various reasons. Make sure all provided arguments are valid.
     """
+
     pass
+
 
 class InvalidDecodeInput(Exception):
     """
     Raised when the built-in decoder :meth:`scratchattach.encoder.Encoding.decode` receives an invalid input.
     """
+
     pass
+
 
 class BadRequest(Exception):
     """
-    Raised when the Scratch API responds with a "Bad Request" error message. This can have various reasons. Make sure all provided arguments are valid. If you provided an "offset" keyword argument, its value shouldn't exceed 40.
+    Raised when the Scratch API responds with a "Bad Request" error message. This can have various reasons. Make sure all provided arguments are valid.
     """
+
     pass
+
 
 class Response429(Exception):
     """
     Raised when the Scratch API responds with a 429 error. This means that your network was ratelimited or blocked by Scratch. If you're using an online IDE (like replit.com), try running the code on your computer.
     """
+
     pass
+
 
 class RequestNotFound(Exception):
     """
     Cloud Requests: Raised when a non-existent cloud request is edited using :meth:`scratchattach.cloud_requests.CloudRequests.edit_request`.
     """
+
     pass
+
 
 class CommentPostFailure(Exception):
     """
     Raised when a comment fails to post. This can have various reasons.
     """
+
     pass

--- a/scratchattach/forum.py
+++ b/scratchattach/forum.py
@@ -29,7 +29,7 @@ class ForumTopic:
 
         self.__dict__.update(entries)
 
-        if "_session" not in self.__dict__.keys():
+        if not hasattr(self, "_session"):
             self._session = None
         if self._session is None:
             self._headers = headers
@@ -132,7 +132,7 @@ class ForumPost:
 
         self.__dict__.update(entries)
 
-        if "_session" not in self.__dict__.keys():
+        if not hasattr(self, "_session"):
             self._session = None
         if self._session is None:
             self._headers = headers

--- a/scratchattach/forum.py
+++ b/scratchattach/forum.py
@@ -4,13 +4,8 @@ import json
 import requests
 from . import user
 from . import exceptions
+from .commons import api_iterative_data, api_iterative_simple, headers
 
-headers = {
-    'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36',
-    "x-csrftoken": "a",
-    "x-requested-with": "XMLHttpRequest",
-    "referer": "https://scratch.mit.edu",
-}
 
 class ForumTopic:
     '''

--- a/scratchattach/project.py
+++ b/scratchattach/project.py
@@ -6,7 +6,7 @@ import requests
 from . import user
 from . import exceptions
 from . import studio
-from .commons import api_iterative_data
+from .commons import api_iterative_data, api_iterative_simple
 
 headers = {
     "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36",
@@ -291,17 +291,9 @@ class Project(PartialProject):
             list<dict>: A list containing the studios this project is in, each studio is represented by a dict.
         """
 
-        def fetch(o, l):
-            resp = requests.get(
-                f"https://api.scratch.mit.edu/users/{self.author}/projects/{self.id}/studios?limit={l}&offset={o}"
-            ).json()
-            if resp == {"code": "BadRequest", "message": ""}:
-                return None
-            return resp
+        url = f"https://api.scratch.mit.edu/users/{self.author}/projects/{self.id}/studios"
 
-        api_data = api_iterative_data(
-            fetch, limit, offset, max_req_limit=20, unpack=True
-        )
+        api_data = api_iterative_simple(url, limit, offset, max_req_limit=20)
         return api_data
 
     def comments(self, *, limit=None, offset=0):
@@ -316,30 +308,27 @@ class Project(PartialProject):
             list<dict>: A list containing the requested comments as dicts.
         """
 
-        def fetch(o, l):
-            resp = requests.get(
-                f"https://api.scratch.mit.edu/users/{self.author}/projects/{self.id}/comments/?limit={l}&offset={o}&cachebust={random.randint(0,9999)}"
-            ).json()
-            if not resp:
-                return None
-            return resp
+        url = f"https://api.scratch.mit.edu/users/{self.author}/projects/{self.id}/comments"
 
-        api_data = api_iterative_data(
-            fetch, limit, offset, max_req_limit=20, unpack=True
+        api_data = api_iterative_simple(
+            url,
+            limit,
+            offset,
+            max_req_limit=20,
+            add_params=f"&cachebust={random.randint(0,9999)}",
         )
         return api_data
 
     def get_comment_replies(self, *, comment_id, limit=None, offset=0):
-        def fetch(o, l):
-            resp = requests.get(
-                f"https://api.scratch.mit.edu/users/{self.author}/projects/{self.id}/comments/{comment_id}/replies?limit={l}&offset={o}&cachebust=&cachebust={random.randint(0,9999)}"
-            ).json()
-            if not resp:
-                return None
-            return resp
 
-        api_data = api_iterative_data(
-            fetch, limit, offset, max_req_limit=25, unpack=True
+        url = f"https://api.scratch.mit.edu/users/{self.author}/projects/{self.id}/comments/{comment_id}/replies"
+
+        api_data = api_iterative_simple(
+            url,
+            limit,
+            offset,
+            max_req_limit=25,
+            add_params=f"&cachebust={random.randint(0,9999)}",
         )
         return api_data
 
@@ -798,15 +787,15 @@ def explore_projects(
         If you want to use these methods, get the explore page projects with :meth:`scratchattach.session.Session.search_projects` instead.
     """
 
-    def fetch(o, l):
-        resp = requests.get(
-            f"https://api.scratch.mit.edu/explore/projects?limit={l}&offset={o}&language={language}&mode={mode}&q={query}"
-        ).json()
-        if resp == {"code": "BadRequest", "message": ""}:
-            return None
-        return resp
+    url = f"https://api.scratch.mit.edu/explore/projects"
 
-    api_data = api_iterative_data(fetch, limit, offset, max_req_limit=40, unpack=True)
+    api_data = api_iterative_simple(
+        url,
+        limit,
+        offset,
+        max_req_limit=40,
+        add_params=f"&language={language}&mode={mode}&q={query}",
+    )
 
     projects = []
     for project in api_data:
@@ -835,17 +824,17 @@ def search_projects(*, query="", mode="trending", language="en", limit=None, off
 
         If you want to use these methods, perform the search with :meth:`scratchattach.session.Session.search_projects` instead.
     """
-    projects = []
 
-    def fetch(o, l):
-        resp = requests.get(
-            f"https://api.scratch.mit.edu/search/projects?limit={l}&offset={o}&language={language}&mode={mode}&q={query}"
-        ).json()
-        if resp == {"code": "BadRequest", "message": ""}:
-            return None
-        return resp
+    url = f"https://api.scratch.mit.edu/search/projects"
 
-    api_data = api_iterative_data(fetch, limit, offset, max_req_limit=40, unpack=True)
+    api_data = api_iterative_simple(
+        url,
+        limit,
+        offset,
+        max_req_limit=40,
+        add_params=f"&language={language}&mode={mode}&q={query}",
+    )
+
     projects = []
     for project in api_data:
         p = Project()

--- a/scratchattach/project.py
+++ b/scratchattach/project.py
@@ -6,14 +6,7 @@ import requests
 from . import user
 from . import exceptions
 from . import studio
-from .commons import api_iterative_data, api_iterative_simple
-
-headers = {
-    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36",
-    "x-csrftoken": "a",
-    "x-requested-with": "XMLHttpRequest",
-    "referer": "https://scratch.mit.edu",
-}
+from .commons import api_iterative_data, api_iterative_simple, headers
 
 
 class PartialProject:
@@ -67,7 +60,7 @@ class PartialProject:
             return resp
 
         api_data = api_iterative_data(
-            fetch, limit, offset, max_req_limit=20, unpack=True
+            fetch, limit, offset, max_req_limit=40, unpack=True
         )
 
         projects = []
@@ -293,7 +286,7 @@ class Project(PartialProject):
 
         url = f"https://api.scratch.mit.edu/users/{self.author}/projects/{self.id}/studios"
 
-        api_data = api_iterative_simple(url, limit, offset, max_req_limit=20)
+        api_data = api_iterative_simple(url, limit, offset, max_req_limit=40)
         return api_data
 
     def comments(self, *, limit=None, offset=0):
@@ -314,7 +307,7 @@ class Project(PartialProject):
             url,
             limit,
             offset,
-            max_req_limit=20,
+            max_req_limit=40,
             add_params=f"&cachebust={random.randint(0,9999)}",
         )
         return api_data
@@ -327,7 +320,7 @@ class Project(PartialProject):
             url,
             limit,
             offset,
-            max_req_limit=25,
+            max_req_limit=40,
             add_params=f"&cachebust={random.randint(0,9999)}",
         )
         return api_data
@@ -824,6 +817,8 @@ def search_projects(*, query="", mode="trending", language="en", limit=None, off
 
         If you want to use these methods, perform the search with :meth:`scratchattach.session.Session.search_projects` instead.
     """
+    if not query:
+        raise ValueError("The query can't be empty for search")
 
     url = f"https://api.scratch.mit.edu/search/projects"
 

--- a/scratchattach/project.py
+++ b/scratchattach/project.py
@@ -737,9 +737,20 @@ def explore_projects(*, query="*", mode="trending", language="en", limit=40, off
         If you want to use these methods, get the explore page projects with :meth:`scratchattach.session.Session.search_projects` instead.
     '''
 
-    r = requests.get(f"https://api.scratch.mit.edu/explore/projects?limit={limit}&offset={offset}&language={language}&mode={mode}&q={query}").json()
     projects = []
 
+    limit2 = limit+offset
+    while (limit2 % 40) != 0:
+        limit2+=1
+    limit2 //= 40
+    offs = 0
+    resp = []
+    for i in range(limit2):
+        resp2 = requests.get(f"https://api.scratch.mit.edu/explore/projects?limit=40&offset={offs}&language={language}&mode={mode}&q={query}").json()
+        if not resp2 == {"code":"BadRequest","message":""}:
+            resp += resp2
+        offs+=40
+    r = resp[offset:][:limit]
     for project in r:
         p = Project()
         p._update_from_dict(project)
@@ -765,9 +776,20 @@ def search_projects(*, query="", mode="trending", language="en", limit=40, offse
 
         If you want to use these methods, perform the search with :meth:`scratchattach.session.Session.search_projects` instead.
     '''
-    r = requests.get(f"https://api.scratch.mit.edu/search/projects?limit={limit}&offset={offset}&language={language}&mode={mode}&q={query}").json()
     projects = []
 
+    limit2 = limit+offset
+    while (limit2 % 40) != 0:
+        limit2+=1
+    limit2 //= 40
+    offs = 0
+    resp = []
+    for i in range(limit2):
+        resp2 = requests.get(f"https://api.scratch.mit.edu/search/projects?limit=40&offset={offs}&language={language}&mode={mode}&q={query}").json()
+        if not resp2 == {"code":"BadRequest","message":""}:
+            resp += resp2
+        offs+=40
+    r = resp[offset:][:limit]
     for project in r:
         p = Project()
         p._update_from_dict(project)

--- a/scratchattach/project.py
+++ b/scratchattach/project.py
@@ -15,12 +15,11 @@ class PartialProject:
     """
 
     def __init__(self, **entries):
-
         self.shared = None
         self.project_token = None
         self.__dict__.update(entries)
 
-        if "_session" not in self.__dict__.keys():
+        if not hasattr(self, "_session"):
             self._session = None
         if self._session is None:
             self._headers = headers
@@ -156,9 +155,9 @@ class Project(PartialProject):
                 headers={
                     "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.88 Safari/537.36",
                     "x-token": self._session.xtoken,
-                    "Pragma" : "no-cache",
-                    "Cache-Control" : "no-cache"
-                }
+                    "Pragma": "no-cache",
+                    "Cache-Control": "no-cache",
+                },
             )
             if "429" in str(project):
                 return "429"
@@ -166,12 +165,13 @@ class Project(PartialProject):
                 return "429"
             project = project.json()
         else:
-            project = requests.get(f"https://api.scratch.mit.edu/projects/{self.id}",
-                headers = {
+            project = requests.get(
+                f"https://api.scratch.mit.edu/projects/{self.id}",
+                headers={
                     "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.88 Safari/537.36",
-                    "Pragma" : "no-cache",
-                    "Cache-Control" : "no-cache"
-                }
+                    "Pragma": "no-cache",
+                    "Cache-Control": "no-cache",
+                },
             )
             if "429" in str(project):
                 return "429"
@@ -317,11 +317,12 @@ class Project(PartialProject):
             offset,
             max_req_limit=40,
             add_params=f"&cachebust={random.randint(0,9999)}",
+            headers=self._headers,
+            cookies=self._cookies,
         )
         return api_data
 
     def get_comment_replies(self, *, comment_id, limit=None, offset=0):
-
         url = f"https://api.scratch.mit.edu/users/{self.author}/projects/{self.id}/comments/{comment_id}/replies"
 
         api_data = api_iterative_simple(
@@ -330,6 +331,8 @@ class Project(PartialProject):
             offset,
             max_req_limit=40,
             add_params=f"&cachebust={random.randint(0,9999)}",
+            headers=self._headers,
+            cookies=self._cookies,
         )
         return api_data
 

--- a/scratchattach/project.py
+++ b/scratchattach/project.py
@@ -1,4 +1,4 @@
-#----- Getting projects
+# ----- Getting projects
 
 import json
 import random
@@ -6,16 +6,17 @@ import requests
 from . import user
 from . import exceptions
 from . import studio
+from .commons import api_iterative_data
 
 headers = {
-    'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36',
+    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36",
     "x-csrftoken": "a",
     "x-requested-with": "XMLHttpRequest",
     "referer": "https://scratch.mit.edu",
 }
 
-class PartialProject:
 
+class PartialProject:
     """
     Represents an unshared Scratch project that can't be accessed.
     """
@@ -37,7 +38,8 @@ class PartialProject:
 
         try:
             self._headers.pop("Cookie")
-        except Exception: pass
+        except Exception:
+            pass
 
         self._json_headers = self._headers
         self._json_headers["accept"] = "application/json"
@@ -48,50 +50,50 @@ class PartialProject:
         Returns:
             list<scratchattach.project.Project>: A list containing the remixes of the project, each project is represented by a Project object.
         """
-        if limit is None:
-            _projects = json.loads(requests.get(
-                f"https://api.scratch.mit.edu/projects/{self.id}/remixes/?offset={offset}",
-                headers = {
+
+        def fetch(o, l):
+            resp = requests.get(
+                f"https://api.scratch.mit.edu/projects/{self.id}/remixes/?limit={l}&offset={o}",
+                headers={
                     "x-csrftoken": "a",
                     "x-requested-with": "XMLHttpRequest",
                     "Cookie": "scratchcsrftoken=a;scratchlanguage=en;",
                     "referer": "https://scratch.mit.edu",
-                    'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36',
-                }
-            ).text)
-        else:
-            _projects = requests.get(
-                f"https://api.scratch.mit.edu/projects/{self.id}/remixes/?limit={limit}&offset={offset}",
-                headers = {
-                    "x-csrftoken": "a",
-                    "x-requested-with": "XMLHttpRequest",
-                    "Cookie": "scratchcsrftoken=a;scratchlanguage=en;",
-                    "referer": "https://scratch.mit.edu",
-                    'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36',
-                }
+                    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36",
+                },
             ).json()
+            if not resp:
+                return None
+            return resp
+
+        api_data = api_iterative_data(
+            fetch, limit, offset, max_req_limit=20, unpack=True
+        )
+
         projects = []
-        for project in _projects:
-            projects.append(Project(
-                author = project["author"]["username"],
-                comments_allowed = project["comments_allowed"],
-                notes=project["description"],
-                created = project["history"]["created"],
-                last_modified = project["history"]["modified"],
-                share_date = project["history"]["shared"],
-                id = project["id"],
-                thumbnail_url = project["image"],
-                instructions = project["instructions"],
-                remix_parent = project["remix"]["parent"],
-                remix_root = project["remix"]["root"],
-                favorites = project["stats"]["favorites"],
-                loves = project["stats"]["loves"],
-                remixes = project["stats"]["remixes"],
-                views = project["stats"]["views"],
-                title = project["title"],
-                url = "https://scratch.mit.edu/projects/" + str(project["id"]),
-                _session = self._session,
-            ))
+        for project in api_data:
+            projects.append(
+                Project(
+                    author=project["author"]["username"],
+                    comments_allowed=project["comments_allowed"],
+                    notes=project["description"],
+                    created=project["history"]["created"],
+                    last_modified=project["history"]["modified"],
+                    share_date=project["history"]["shared"],
+                    id=project["id"],
+                    thumbnail_url=project["image"],
+                    instructions=project["instructions"],
+                    remix_parent=project["remix"]["parent"],
+                    remix_root=project["remix"]["root"],
+                    favorites=project["stats"]["favorites"],
+                    loves=project["stats"]["loves"],
+                    remixes=project["stats"]["remixes"],
+                    views=project["stats"]["views"],
+                    title=project["title"],
+                    url="https://scratch.mit.edu/projects/" + str(project["id"]),
+                    _session=self._session,
+                )
+            )
         return projects
 
     def is_shared(self):
@@ -102,9 +104,9 @@ class PartialProject:
         p = get_project(self.id)
         return isinstance(p, Project)
 
-class Project(PartialProject):
 
-    '''
+class Project(PartialProject):
+    """
     Represents a Scratch project.
 
     Attributes:
@@ -146,7 +148,7 @@ class Project(PartialProject):
     :.project_token: The project token (required to access the project json)
 
     :.update(): Updates the attributes
-    '''
+    """
 
     def __str__(self):
         return self.title
@@ -158,10 +160,10 @@ class Project(PartialProject):
         if self._session is not None:
             project = requests.get(
                 f"https://api.scratch.mit.edu/projects/{self.id}",
-                headers = {
+                headers={
                     "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.88 Safari/537.36",
                     "x-token": self._session.xtoken,
-                }
+                },
             )
             if "429" in str(project):
                 return "429"
@@ -182,21 +184,27 @@ class Project(PartialProject):
 
     def download(self, *, filename=None, dir=""):
         """
-            Downloads the project json to the given directory.
+        Downloads the project json to the given directory.
 
-            Args:
-                filename (str): The name that will be given to the downloaded file.
-                dir (str): The path of the directory the file will be saved in.
+        Args:
+            filename (str): The name that will be given to the downloaded file.
+            dir (str): The path of the directory the file will be saved in.
         """
         try:
             if filename is None:
                 filename = str(self.id)
             self.update()
-            response = requests.get(f"https://projects.scratch.mit.edu/{self.id}?token={self.project_token}")
+            response = requests.get(
+                f"https://projects.scratch.mit.edu/{self.id}?token={self.project_token}"
+            )
             filename = filename.replace(".sb3", "")
-            open(f"{dir}{filename}.sb3", 'wb').write(response.content)
+            open(f"{dir}{filename}.sb3", "wb").write(response.content)
         except Exception:
-            raise(exceptions.FetchError("Method only works for projects created with Scratch 3"))
+            raise (
+                exceptions.FetchError(
+                    "Method only works for projects created with Scratch 3"
+                )
+            )
 
     def get_raw_json(self):
         """
@@ -207,9 +215,15 @@ class Project(PartialProject):
         """
         try:
             self.update()
-            return requests.get(f"https://projects.scratch.mit.edu/{self.id}?token={self.project_token}").json()
+            return requests.get(
+                f"https://projects.scratch.mit.edu/{self.id}?token={self.project_token}"
+            ).json()
         except Exception:
-            raise(exceptions.FetchError("Method only works for projects created with Scratch 3"))
+            raise (
+                exceptions.FetchError(
+                    "Method only works for projects created with Scratch 3"
+                )
+            )
 
     def get_creator_agent(self):
         """
@@ -220,20 +234,26 @@ class Project(PartialProject):
         """
         try:
             self.update()
-            return requests.get(f"https://projects.scratch.mit.edu/{self.id}?token={self.project_token}").json()["meta"]["agent"]
+            return requests.get(
+                f"https://projects.scratch.mit.edu/{self.id}?token={self.project_token}"
+            ).json()["meta"]["agent"]
         except Exception:
-            raise(exceptions.FetchError("Method only works for projects created with Scratch 3"))
+            raise (
+                exceptions.FetchError(
+                    "Method only works for projects created with Scratch 3"
+                )
+            )
 
     def _update_from_dict(self, project):
         try:
             self.id = int(project["id"])
         except KeyError:
             pass
-        self.url = "https://scratch.mit.edu/projects/"+str(self.id)
+        self.url = "https://scratch.mit.edu/projects/" + str(self.id)
         self.author = project["author"]["username"]
         self.comments_allowed = project["comments_allowed"]
         self.instructions = project["instructions"]
-        self.notes=project["description"]
+        self.notes = project["description"]
         self.created = project["history"]["created"]
         self.last_modified = project["history"]["modified"]
         self.share_date = project["history"]["shared"]
@@ -265,15 +285,26 @@ class Project(PartialProject):
         except AttributeError:
             return user.get_user(self.author)
 
-    def studios(self, *, limit=40, offset=0):
+    def studios(self, *, limit=None, offset=0):
         """
         Returns:
             list<dict>: A list containing the studios this project is in, each studio is represented by a dict.
         """
-        data = requests.get(f"https://api.scratch.mit.edu/users/{self.author}/projects/{self.id}/studios?limit={limit}&offset={offset}").json()
-        return data
-    
-    def comments(self, *, limit=40, offset=0):
+
+        def fetch(o, l):
+            resp = requests.get(
+                f"https://api.scratch.mit.edu/users/{self.author}/projects/{self.id}/studios?limit={l}&offset={o}"
+            ).json()
+            if resp == {"code": "BadRequest", "message": ""}:
+                return None
+            return resp
+
+        api_data = api_iterative_data(
+            fetch, limit, offset, max_req_limit=20, unpack=True
+        )
+        return api_data
+
+    def comments(self, *, limit=None, offset=0):
         """
         Returns the comments posted on the project (except for replies. To get replies use :meth:`scratchattach.project.Project.get_comment_replies`).
 
@@ -285,44 +316,46 @@ class Project(PartialProject):
             list<dict>: A list containing the requested comments as dicts.
         """
 
-        comments = []
-        while len(comments) < limit:
-            r = requests.get(
-                f"https://api.scratch.mit.edu/users/{self.author}/projects/{self.id}/comments/?limit={min(40, limit-len(comments))}&offset={offset}&cachebust={random.randint(0,9999)}"
+        def fetch(o, l):
+            resp = requests.get(
+                f"https://api.scratch.mit.edu/users/{self.author}/projects/{self.id}/comments/?limit={l}&offset={o}&cachebust={random.randint(0,9999)}"
             ).json()
-            if len(r) != 40:
-                comments = comments + r
-                break
-            offset += 40
-            comments = comments + r
-        return comments
+            if not resp:
+                return None
+            return resp
 
-    def get_comment_replies(self, *, comment_id, limit=40, offset=0):
-        comments = []
-        while len(comments) < limit:
-            r = requests.get(
-                f"https://api.scratch.mit.edu/users/{self.author}/projects/{self.id}/comments/{comment_id}/replies?limit={min(40, limit-len(comments))}&offset={offset}&cachebust=&cachebust={random.randint(0,9999)}"
+        api_data = api_iterative_data(
+            fetch, limit, offset, max_req_limit=20, unpack=True
+        )
+        return api_data
+
+    def get_comment_replies(self, *, comment_id, limit=None, offset=0):
+        def fetch(o, l):
+            resp = requests.get(
+                f"https://api.scratch.mit.edu/users/{self.author}/projects/{self.id}/comments/{comment_id}/replies?limit={l}&offset={o}&cachebust=&cachebust={random.randint(0,9999)}"
             ).json()
-            if len(r) != 40:
-                comments = comments + r
-                break
-            offset += 40
-            comments = comments + r
-        return comments
+            if not resp:
+                return None
+            return resp
+
+        api_data = api_iterative_data(
+            fetch, limit, offset, max_req_limit=25, unpack=True
+        )
+        return api_data
 
     def love(self):
         """
         Posts a love on the project. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_project`
         """
         if self._session is None:
-            raise(exceptions.Unauthenticated)
+            raise (exceptions.Unauthenticated)
             return
         r = requests.post(
             f"https://api.scratch.mit.edu/proxy/projects/{self.id}/loves/user/{self._session._username}",
             headers=self._headers,
             cookies=self._cookies,
         ).json()
-        if r['userLove'] is False:
+        if r["userLove"] is False:
             self.love()
 
     def unlove(self):
@@ -330,14 +363,14 @@ class Project(PartialProject):
         Removes the love from this project. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_project`
         """
         if self._session is None:
-            raise(exceptions.Unauthenticated)
+            raise (exceptions.Unauthenticated)
             return
         r = requests.delete(
             f"https://api.scratch.mit.edu/proxy/projects/{self.id}/loves/user/{self._session._username}",
-            headers = self._headers,
-            cookies = self._cookies,
+            headers=self._headers,
+            cookies=self._cookies,
         ).json()
-        if r['userLove'] is True:
+        if r["userLove"] is True:
             self.unlove()
 
     def favorite(self):
@@ -345,14 +378,14 @@ class Project(PartialProject):
         Posts a favorite on the project. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_project`
         """
         if self._session is None:
-            raise(exceptions.Unauthenticated)
+            raise (exceptions.Unauthenticated)
             return
         r = requests.post(
             f"https://api.scratch.mit.edu/proxy/projects/{self.id}/favorites/user/{self._session._username}",
-            headers = self._headers,
-            cookies = self._cookies,
+            headers=self._headers,
+            cookies=self._cookies,
         ).json()
-        if r['userFavorite'] is False:
+        if r["userFavorite"] is False:
             self.favorite()
 
     def unfavorite(self):
@@ -360,16 +393,15 @@ class Project(PartialProject):
         Removes the favorite from this project. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_project`
         """
         if self._session is None:
-            raise(exceptions.Unauthenticated)
+            raise (exceptions.Unauthenticated)
             return
         r = requests.delete(
             f"https://api.scratch.mit.edu/proxy/projects/{self.id}/favorites/user/{self._session._username}",
-            headers = self._headers,
-            cookies = self._cookies,
+            headers=self._headers,
+            cookies=self._cookies,
         ).json()
-        if r['userFavorite'] is True:
+        if r["userFavorite"] is True:
             self.unfavorite()
-
 
     def post_view(self):
         """
@@ -385,77 +417,76 @@ class Project(PartialProject):
         Disables commenting on the project. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_project`
         """
         if self._session is None:
-            raise(exceptions.Unauthenticated)
+            raise (exceptions.Unauthenticated)
             return
         if self._session._username != self.author:
-            raise(exceptions.Unauthorized)
+            raise (exceptions.Unauthorized)
             return
-        data = {
-            "comments_allowed" : False
-        }
-        self._update_from_dict(requests.put(
-            f"https://api.scratch.mit.edu/projects/{self.id}/",
-            headers = self._json_headers,
-            cookies = self._cookies,
-            data = json.dumps(data)
-        ).json())
+        data = {"comments_allowed": False}
+        self._update_from_dict(
+            requests.put(
+                f"https://api.scratch.mit.edu/projects/{self.id}/",
+                headers=self._json_headers,
+                cookies=self._cookies,
+                data=json.dumps(data),
+            ).json()
+        )
 
     def turn_on_commenting(self):
         """
         Enables commenting on the project. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_project`
         """
         if self._session is None:
-            raise(exceptions.Unauthenticated)
+            raise (exceptions.Unauthenticated)
             return
         if self._session._username != self.author:
-            raise(exceptions.Unauthorized)
+            raise (exceptions.Unauthorized)
             return
-        data = {
-            "comments_allowed" : True
-        }
-        self._update_from_dict(requests.put(
-            f"https://api.scratch.mit.edu/projects/{self.id}/",
-            headers = self._json_headers,
-            cookies = self._cookies,
-            data = json.dumps(data)
-        ).json())
-
-
+        data = {"comments_allowed": True}
+        self._update_from_dict(
+            requests.put(
+                f"https://api.scratch.mit.edu/projects/{self.id}/",
+                headers=self._json_headers,
+                cookies=self._cookies,
+                data=json.dumps(data),
+            ).json()
+        )
 
     def toggle_commenting(self):
         """
         Switches commenting on / off on the project (If comments are on, they will be turned off, else they will be turned on). You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_project`
         """
         if self._session is None:
-            raise(exceptions.Unauthenticated)
+            raise (exceptions.Unauthenticated)
             return
         if self._session._username != self.author:
-            raise(exceptions.Unauthorized)
+            raise (exceptions.Unauthorized)
             return
-        data = {
-            "comments_allowed" : not self.comments_allowed
-        }
-        self._update_from_dict(requests.put(
-            f"https://api.scratch.mit.edu/projects/{self.id}/",
-            headers = self._json_headers,
-            cookies = self._cookies,
-            data = json.dumps(data)
-        ).json())
+        data = {"comments_allowed": not self.comments_allowed}
+        self._update_from_dict(
+            requests.put(
+                f"https://api.scratch.mit.edu/projects/{self.id}/",
+                headers=self._json_headers,
+                cookies=self._cookies,
+                data=json.dumps(data),
+            ).json()
+        )
 
     def share(self):
         """
         Shares the project. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_project`
         """
         if self._session is None:
-            raise(exceptions.Unauthenticated)
+            raise (exceptions.Unauthenticated)
             return
         if self._session._username != self.author:
-            raise(exceptions.Unauthorized)
+            raise (exceptions.Unauthorized)
             return
         if self.shared is not True:
-            requests.put(f"https://api.scratch.mit.edu/proxy/projects/{self.id}/share/",
-                headers = self._json_headers,
-                cookies = self._cookies,
+            requests.put(
+                f"https://api.scratch.mit.edu/proxy/projects/{self.id}/share/",
+                headers=self._json_headers,
+                cookies=self._cookies,
             )
 
     def unshare(self):
@@ -463,15 +494,16 @@ class Project(PartialProject):
         Unshares the project. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_project`
         """
         if self._session is None:
-            raise(exceptions.Unauthenticated)
+            raise (exceptions.Unauthenticated)
             return
         if self._session._username != self.author:
-            raise(exceptions.Unauthorized)
+            raise (exceptions.Unauthorized)
             return
         if self.shared is not False:
-            requests.put(f"https://api.scratch.mit.edu/proxy/projects/{self.id}/unshare/",
-                headers = self._json_headers,
-                cookies = self._cookies,
+            requests.put(
+                f"https://api.scratch.mit.edu/proxy/projects/{self.id}/unshare/",
+                headers=self._json_headers,
+                cookies=self._cookies,
             )
 
     def set_thumbnail(self, *, file):
@@ -479,18 +511,18 @@ class Project(PartialProject):
         You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_project`
         """
         if self._session is None:
-            raise(exceptions.Unauthenticated)
+            raise (exceptions.Unauthenticated)
             return
         if self._session._username != self.author:
-            raise(exceptions.Unauthorized)
+            raise (exceptions.Unauthorized)
             return
         with open(file, "rb") as f:
             thumbnail = f.read()
         requests.post(
             f"https://scratch.mit.edu/internalapi/project/thumbnail/{self.id}/set/",
-            data = thumbnail,
-            headers = self._headers,
-            cookies = self._cookies,
+            data=thumbnail,
+            headers=self._headers,
+            cookies=self._cookies,
         )
 
     def delete_comment(self, *, comment_id):
@@ -501,15 +533,15 @@ class Project(PartialProject):
             comment_id: The id of the comment that should be deleted
         """
         if self._session is None:
-            raise(exceptions.Unauthenticated)
+            raise (exceptions.Unauthenticated)
             return
         if self._session._username != self.author:
-            raise(exceptions.Unauthorized)
+            raise (exceptions.Unauthorized)
             return
         return requests.delete(
             f"https://api.scratch.mit.edu/proxy/comments/project/{self.id}/comment/{comment_id}/",
-            headers = self._headers,
-            cookies = self._cookies,
+            headers=self._headers,
+            cookies=self._cookies,
         ).headers
 
     def report_comment(self, *, comment_id):
@@ -520,12 +552,12 @@ class Project(PartialProject):
             comment_id: The id of the comment that should be reported
         """
         if self._session is None:
-            raise(exceptions.Unauthenticated)
+            raise (exceptions.Unauthenticated)
             return
         return requests.delete(
             f"https://api.scratch.mit.edu/proxy/comments/project/{self.id}/comment/{comment_id}/report",
-            headers = self._headers,
-            cookies = self._cookies,
+            headers=self._headers,
+            cookies=self._cookies,
         )
 
     def post_comment(self, content, *, parent_id="", commentee_id=""):
@@ -540,7 +572,7 @@ class Project(PartialProject):
             commentee_id: ID of the user that will be mentioned in your comment and will receive a message about your comment. If you don't want to mention a user, don't put the argument.
         """
         if self._session is None:
-            raise(exceptions.Unauthenticated)
+            raise (exceptions.Unauthenticated)
             return
         data = {
             "commentee_id": commentee_id,
@@ -549,13 +581,14 @@ class Project(PartialProject):
         }
         headers = self._json_headers
         headers["referer"] = "https://scratch.mit.edu/projects/" + str(self.id) + "/"
-        return json.loads(requests.post(
-            f"https://api.scratch.mit.edu/proxy/comments/project/{self.id}/",
-            headers = headers,
-            cookies = self._cookies,
-            data=json.dumps(data),
-        ).text)
-
+        return json.loads(
+            requests.post(
+                f"https://api.scratch.mit.edu/proxy/comments/project/{self.id}/",
+                headers=headers,
+                cookies=self._cookies,
+                data=json.dumps(data),
+            ).text
+        )
 
     def reply_comment(self, content, *, parent_id, commentee_id=""):
         """
@@ -568,7 +601,9 @@ class Project(PartialProject):
             parent_id: ID of the comment you want to reply to
             commentee_id: ID of the user that will be mentioned in your comment and will receive a message about your comment. If you don't want to mention a user, don't put the argument.
         """
-        return self.post_comment(content, parent_id=parent_id, commentee_id=commentee_id)
+        return self.post_comment(
+            content, parent_id=parent_id, commentee_id=commentee_id
+        )
 
     def set_json(self, json_data):
         """
@@ -582,25 +617,25 @@ class Project(PartialProject):
             json_data = json.loads(json_data)
 
         if self._session is None:
-            raise(exceptions.Unauthenticated)
+            raise (exceptions.Unauthenticated)
             return
         if self._session._username != self.author:
-            raise(exceptions.Unauthorized("You must be the project owner to do this."))
+            raise (exceptions.Unauthorized("You must be the project owner to do this."))
             return
 
         r = requests.put(
             f"https://projects.scratch.mit.edu/{self.id}",
-            headers = self._headers,
-            cookies = self._cookies,
+            headers=self._headers,
+            cookies=self._cookies,
             json=json_data,
         ).json()
-    
+
     def upload_json_from(self, project_id):
         """
         Uploads the project json from the project with the given to the project represented by this Project object
         """
         if self._session is None:
-            raise(exceptions.Unauthenticated)
+            raise (exceptions.Unauthenticated)
             return
         other_project = self._session.connect_project(project_id)
         self.set_json(other_project.get_raw_json())
@@ -610,15 +645,17 @@ class Project(PartialProject):
         Changes the projects title. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_project`
         """
         if self._session is None:
-            raise(exceptions.Unauthenticated)
+            raise (exceptions.Unauthenticated)
             return
         if self._session._username != self.author:
-            raise(exceptions.Unauthorized("You must be the project owner to do this."))
+            raise (exceptions.Unauthorized("You must be the project owner to do this."))
             return
-        r = requests.put(f"https://api.scratch.mit.edu/projects/{self.id}",
-            headers = self._headers,
-            cookies = self._cookies,
-            data=json.dumps({"title":text})).json()
+        r = requests.put(
+            f"https://api.scratch.mit.edu/projects/{self.id}",
+            headers=self._headers,
+            cookies=self._cookies,
+            data=json.dumps({"title": text}),
+        ).json()
         return self._update_from_dict(r)
 
     def set_instructions(self, text):
@@ -626,15 +663,17 @@ class Project(PartialProject):
         Changes the projects instructions. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_project`
         """
         if self._session is None:
-            raise(exceptions.Unauthenticated)
+            raise (exceptions.Unauthenticated)
             return
         if self._session._username != self.author:
-            raise(exceptions.Unauthorized("You must be the project owner to do this."))
+            raise (exceptions.Unauthorized("You must be the project owner to do this."))
             return
-        r = requests.put(f"https://api.scratch.mit.edu/projects/{self.id}",
-            headers = self._headers,
-            cookies = self._cookies,
-            data=json.dumps({"instructions":text})).json()
+        r = requests.put(
+            f"https://api.scratch.mit.edu/projects/{self.id}",
+            headers=self._headers,
+            cookies=self._cookies,
+            data=json.dumps({"instructions": text}),
+        ).json()
         return self._update_from_dict(r)
 
     def set_notes(self, text):
@@ -642,15 +681,17 @@ class Project(PartialProject):
         Changes the projects notes and credits. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_project`
         """
         if self._session is None:
-            raise(exceptions.Unauthenticated)
+            raise (exceptions.Unauthenticated)
             return
         if self._session._username != self.author:
-            raise(exceptions.Unauthorized("You must be the project owner to do this."))
+            raise (exceptions.Unauthorized("You must be the project owner to do this."))
             return
-        r = requests.put(f"https://api.scratch.mit.edu/projects/{self.id}",
-            headers = self._headers,
-            cookies = self._cookies,
-            data=json.dumps({"description":text})).json()
+        r = requests.put(
+            f"https://api.scratch.mit.edu/projects/{self.id}",
+            headers=self._headers,
+            cookies=self._cookies,
+            data=json.dumps({"description": text}),
+        ).json()
         return self._update_from_dict(r)
 
     def ranks(self):
@@ -660,7 +701,9 @@ class Project(PartialProject):
         Returns:
             dict: A dict containing the project's ranks. If the ranks aren't available, all values will be -1.
         """
-        return requests.get(f"https://scratchdb.lefty.one/v3/project/info/{self.id}").json()["statistics"]["ranks"]
+        return requests.get(
+            f"https://scratchdb.lefty.one/v3/project/info/{self.id}"
+        ).json()["statistics"]["ranks"]
 
     def moderation_status(self):
         """
@@ -680,13 +723,15 @@ class Project(PartialProject):
         no_remixes: Unable to fetch the project's moderation status.
         """
         try:
-            return requests.get(f"https://jeffalo.net/api/nfe/?project={self.id}").json()["status"]
+            return requests.get(
+                f"https://jeffalo.net/api/nfe/?project={self.id}"
+            ).json()["status"]
         except Exception:
-            raise(exceptions.FetchError)
-
+            raise (exceptions.FetchError)
 
 
 # ------ #
+
 
 def get_project(project_id):
     """
@@ -707,18 +752,34 @@ def get_project(project_id):
         project = Project(id=int(project_id))
         u = project.update()
         if u == "429":
-            raise(exceptions.Response429("Your network is blocked or rate-limited by Scratch.\nIf you're using an online IDE like replit.com, try running the code on your computer."))
+            raise (
+                exceptions.Response429(
+                    "Your network is blocked or rate-limited by Scratch.\nIf you're using an online IDE like replit.com, try running the code on your computer."
+                )
+            )
         if not u:
-            project = PartialProject(id=int(project_id), author=None, title=None, shared=False, instructions=None, notes=None, loves=None, views=None, favorites=None)
+            project = PartialProject(
+                id=int(project_id),
+                author=None,
+                title=None,
+                shared=False,
+                instructions=None,
+                notes=None,
+                loves=None,
+                views=None,
+                favorites=None,
+            )
         return project
     except KeyError:
         return None
     except Exception as e:
-        raise(e)
+        raise (e)
 
 
-def explore_projects(*, query="*", mode="trending", language="en", limit=40, offset=0):
-    '''
+def explore_projects(
+    *, query="*", mode="trending", language="en", limit=None, offset=0
+):
+    """
     Gets projects from the explore page without logging in.
 
     Keyword arguments:
@@ -735,30 +796,28 @@ def explore_projects(*, query="*", mode="trending", language="en", limit=40, off
         Any methods that require authentication (like project.love) will not work on the returned objects.
 
         If you want to use these methods, get the explore page projects with :meth:`scratchattach.session.Session.search_projects` instead.
-    '''
+    """
+
+    def fetch(o, l):
+        resp = requests.get(
+            f"https://api.scratch.mit.edu/explore/projects?limit={l}&offset={o}&language={language}&mode={mode}&q={query}"
+        ).json()
+        if resp == {"code": "BadRequest", "message": ""}:
+            return None
+        return resp
+
+    api_data = api_iterative_data(fetch, limit, offset, max_req_limit=40, unpack=True)
 
     projects = []
-
-    limit2 = limit+offset
-    while (limit2 % 40) != 0:
-        limit2+=1
-    limit2 //= 40
-    offs = 0
-    resp = []
-    for i in range(limit2):
-        resp2 = requests.get(f"https://api.scratch.mit.edu/explore/projects?limit=40&offset={offs}&language={language}&mode={mode}&q={query}").json()
-        if not resp2 == {"code":"BadRequest","message":""}:
-            resp += resp2
-        offs+=40
-    r = resp[offset:][:limit]
-    for project in r:
+    for project in api_data:
         p = Project()
         p._update_from_dict(project)
         projects.append(p)
     return projects
 
-def search_projects(*, query="", mode="trending", language="en", limit=40, offset=0):
-    '''
+
+def search_projects(*, query="", mode="trending", language="en", limit=None, offset=0):
+    """
     Uses the Scratch search to search projects without logging in.
 
     Keyword arguments:
@@ -775,22 +834,20 @@ def search_projects(*, query="", mode="trending", language="en", limit=40, offse
         Any methods that require authentication (like project.love) will not work on the returned objects.
 
         If you want to use these methods, perform the search with :meth:`scratchattach.session.Session.search_projects` instead.
-    '''
+    """
     projects = []
 
-    limit2 = limit+offset
-    while (limit2 % 40) != 0:
-        limit2+=1
-    limit2 //= 40
-    offs = 0
-    resp = []
-    for i in range(limit2):
-        resp2 = requests.get(f"https://api.scratch.mit.edu/search/projects?limit=40&offset={offs}&language={language}&mode={mode}&q={query}").json()
-        if not resp2 == {"code":"BadRequest","message":""}:
-            resp += resp2
-        offs+=40
-    r = resp[offset:][:limit]
-    for project in r:
+    def fetch(o, l):
+        resp = requests.get(
+            f"https://api.scratch.mit.edu/search/projects?limit={l}&offset={o}&language={language}&mode={mode}&q={query}"
+        ).json()
+        if resp == {"code": "BadRequest", "message": ""}:
+            return None
+        return resp
+
+    api_data = api_iterative_data(fetch, limit, offset, max_req_limit=40, unpack=True)
+    projects = []
+    for project in api_data:
         p = Project()
         p._update_from_dict(project)
         projects.append(p)

--- a/scratchattach/session.py
+++ b/scratchattach/session.py
@@ -101,7 +101,7 @@ class Session():
         Returns:
             scratchattach.user.User: Object representing the user associated with the log in / session.
         '''
-        if not "_user" in self.__dict__:
+        if not hasattr(self, "_user"):
             self._user = self.connect_user(self._username)
         return self._user
 

--- a/scratchattach/session.py
+++ b/scratchattach/session.py
@@ -289,9 +289,19 @@ class Session():
         Returns:
             list<scratchattach.project.Project>: List that contains the search results.
         '''
-        r = requests.get(f"https://api.scratch.mit.edu/search/projects?limit={limit}&offset={offset}&language={language}&mode={mode}&q={query}").json()
+        limit2 = limit+offset
+        while (limit2 % 40) != 0:
+            limit2+=1
+        limit2 //= 40
+        offs = 0
+        resp = []
+        for i in range(limit2):
+            resp2 = requests.get(f"https://api.scratch.mit.edu/search/projects?limit=40&offset={offs}&language={language}&mode={mode}&q={query}").json()
+            if not resp2 == {"code":"BadRequest","message":""}:
+                resp += resp2
+            offs+=40
+        r = resp[offset:][:limit]
         projects = []
-
         for project_dict in r:
             p = project.Project(_session = self)
             p._update_from_dict(project_dict)
@@ -311,9 +321,19 @@ class Session():
         Returns:
             list<scratchattach.project.Project>: List that contains the explore page projects.
         '''
-        r = requests.get(f"https://api.scratch.mit.edu/explore/projects?limit={limit}&offset={offset}&language={language}&mode={mode}&q={query}").json()
+        limit2 = limit+offset
+        while (limit2 % 40) != 0:
+            limit2+=1
+        limit2 //= 40
+        offs = 0
+        resp = []
+        for i in range(limit2):
+            resp2 = requests.get(f"https://api.scratch.mit.edu/explore/projects?limit=40&offset={offs}&language={language}&mode={mode}&q={query}").json()
+            if not resp2 == {"code":"BadRequest","message":""}:
+                resp += resp2
+            offs+=40
+        r = resp[offset:][:limit]
         projects = []
-
         for project_dict in r:
             p = project.Project(_session = self)
             p._update_from_dict(project_dict)

--- a/scratchattach/session.py
+++ b/scratchattach/session.py
@@ -11,13 +11,8 @@ from . import project
 from . import exceptions
 from . import studio
 from . import forum
+from .commons import api_iterative_data, api_iterative_simple, headers
 
-headers = {
-    'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36',
-    "x-csrftoken": "a",
-    "x-requested-with": "XMLHttpRequest",
-    "referer": "https://scratch.mit.edu",
-}
 
 class Session():
 

--- a/scratchattach/studio.py
+++ b/scratchattach/studio.py
@@ -43,10 +43,9 @@ class Studio:
     """
 
     def __init__(self, **entries):
-
         self.__dict__.update(entries)
 
-        if "_session" not in self.__dict__.keys():
+        if not hasattr(self, "_session"):
             self._session = None
         if self._session is None:
             self._headers = headers
@@ -137,7 +136,6 @@ class Studio:
         return api_data
 
     def get_comment_replies(self, *, comment_id, limit=None, offset=0):
-
         url = f"https://api.scratch.mit.edu/studios/{self.id}/comments/{comment_id}/replies"
 
         api_data = api_iterative_simple(
@@ -301,7 +299,7 @@ class Studio:
                 cookies=self._cookies,
             ).json()
         except Exception:
-            raise(exceptions.Unauthorized)
+            raise (exceptions.Unauthorized)
 
     def promote_curator(self, curator):
         """
@@ -316,7 +314,7 @@ class Studio:
                 cookies=self._cookies,
             ).json()
         except Exception:
-            raise(exceptions.Unauthorized)
+            raise (exceptions.Unauthorized)
 
     def remove_curator(self, curator):
         """
@@ -331,7 +329,7 @@ class Studio:
                 cookies=self._cookies,
             ).json()
         except Exception:
-            raise(exceptions.Unauthorized)
+            raise (exceptions.Unauthorized)
 
     def leave(self):
         """
@@ -501,7 +499,6 @@ class Studio:
         self.comments_allowed = not self.comments_allowed
 
     def activity(self, *, limit=None, offset=0):
-
         url = f"https://api.scratch.mit.edu/studios/{self.id}/activity"
 
         api_data = api_iterative_simple(
@@ -569,7 +566,6 @@ def search_studios(*, query="", mode="trending", language="en", limit=None, offs
 
 
 def explore_studios(*, query="", mode="trending", language="en", limit=None, offset=0):
-
     url = f"https://api.scratch.mit.edu/explore/studios"
 
     api_data = api_iterative_simple(

--- a/scratchattach/studio.py
+++ b/scratchattach/studio.py
@@ -528,7 +528,17 @@ def get_studio(studio_id):
         raise(e)
 
 def search_studios(*, query="", mode="trending", language="en", limit=40, offset=0):
-    return requests.get(f"https://api.scratch.mit.edu/search/studios?limit={limit}&offset={offset}&language={language}&mode={mode}&q={query}").json()
-
+    limit2 = limit+offset
+    while (limit2 % 40) != 0:
+        limit2+=1
+    limit2 //= 40
+    offs = 0
+    resp = []
+    for i in range(limit2):
+        resp2 = requests.get(f"https://api.scratch.mit.edu/search/studios?limit=40&offset={offs}&language={language}&mode={mode}&q={query}").json()
+        if not resp2 == {"code":"BadRequest","message":""}:
+            resp += resp2
+        offs+=40
+    return resp[offset:][:limit]
 def explore_studios(*, query="", mode="trending", language="en", limit=40, offset=0):
     return requests.get(f"https://api.scratch.mit.edu/explore/studios?limit={limit}&offset={offset}&language={language}&mode={mode}&q={query}").json()

--- a/scratchattach/studio.py
+++ b/scratchattach/studio.py
@@ -541,4 +541,15 @@ def search_studios(*, query="", mode="trending", language="en", limit=40, offset
         offs+=40
     return resp[offset:][:limit]
 def explore_studios(*, query="", mode="trending", language="en", limit=40, offset=0):
-    return requests.get(f"https://api.scratch.mit.edu/explore/studios?limit={limit}&offset={offset}&language={language}&mode={mode}&q={query}").json()
+    limit2 = limit+offset
+    while (limit2 % 40) != 0:
+        limit2+=1
+    limit2 //= 40
+    offs = 0
+    resp = []
+    for i in range(limit2):
+        resp2 = requests.get(f"https://api.scratch.mit.edu/explore/studios?limit=40&offset={offs}&language={language}&mode={mode}&q={query}").json()
+        if not resp2 == {"code":"BadRequest","message":""}:
+            resp += resp2
+        offs+=40
+    return resp[offset:][:limit]

--- a/scratchattach/user.py
+++ b/scratchattach/user.py
@@ -6,13 +6,8 @@ from . import project
 from . import exceptions
 from . import forum
 from bs4 import BeautifulSoup
+from .commons import headers
 
-headers = {
-    'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36',
-    "x-csrftoken": "a",
-    "x-requested-with": "XMLHttpRequest",
-    "referer": "https://scratch.mit.edu",
-}
 
 class User:
 

--- a/scratchattach/user.py
+++ b/scratchattach/user.py
@@ -35,17 +35,17 @@ class User:
     def __init__(self, **entries):
         self.__dict__.update(entries)
 
-        if "bio" in self.__dict__:
+        if hasattr(self, "bio"):
             self.about_me = self.bio
-        if "status" in self.__dict__:
+        if hasattr(self, "status"):
             self.wiwo = self.status
 
-        if "name" in self.__dict__.keys():
+        if hasattr(self, "name"):
             self.username = self.name
-        if "username" in self.__dict__.keys():
+        if hasattr(self, "username"):
             self.name = self.username
 
-        if "_session" not in self.__dict__.keys():
+        if not hasattr(self, "_session"):
             self._session = None
         if self._session is None:
             self._headers = headers


### PR DESCRIPTION
This is an improved replacement pr for #188. If this gets merged, #188 needs to be closed.

Right now, if you try to request more than 40 data entries from various functions with api requests, it won't work.
This is fixed here by introducing **api_iterative_data** and **api_iterative_simple** which iteratively fetch data from a url until the end.
These functions are moved to a separate file: commons.py
This module is not imported from \_\_init\_\_ (not exposed). Now it also contains common headers for requests.

TASKS TO DO:
- [x] api_iterative_data
- [x] A simple wrapper for api_iterative_data
- [x] Rework all project functions and retain compatibility
- [x] Rework all studio functions and retain compatibility
- [x] Adapt for new commits (since Apr 2)
- [ ] Better headers and cookies management
- [ ] Rework all user iterative functions and retain compatibility
- [ ] Rework get_cloud_logs
- [ ] Move some stuff to commons.py
- [ ] Adapt (and possibly expand) wiki

The PR **FORMATS** project.py, studio.py (idk why this whole project isn't formatted) with [black](https://github.com/psf/black). This can create incompatibilities for existing PRs but will MASSIVELY help in the future with diffs.

Other changes:
- Created **commons.py**
- Moved headers to **commons.py**
- fixed a bug where if the comments num % 40, **comments** and **get_comment_replies** fetch excess batches up to limit
- fixed typo in **studio.host** code
- improved class attr check