### PR TITLE
Fix bool types

### DIFF
--- a/scratchattach/cloud_requests.py
+++ b/scratchattach/cloud_requests.py
@@ -378,7 +378,7 @@ class CloudRequests:
             except Exception:
                 send_as_integer = False
             else:
-                send_as_integer = not "-" in str(output)
+                send_as_integer = not ("-" in str(output)) and not (type(output)==bool)
         else:
             send_as_integer = False
 


### PR DESCRIPTION
when a request returns a bool, it causes an error because 1==True and 0==False
you may want to convert it to "true", but thats your choice, i just fixed the error