### PR TITLE
get loved projects of a user

### DIFF
--- a/scratchattach/site/session.py
+++ b/scratchattach/site/session.py
@@ -520,13 +520,14 @@ class Session(BaseSiteComponent):
         Returns:
             scratchattach.cloud.TwCloud: An object representing the TurboWarp cloud of a project.
         """
-        return cloud.TwCloud(project_id=project_id, purpose=purpose, contact=contact, cloud_host=cloud_host, _session=self)
+        return cloud.TwCloud(project_id=project_id, purpose=purpose, contact=contact, cloud_host=cloud_host) #, _session=self)
+                                                                                                             # PyCharm is giving a warning for this argument - unexpected argument
 
     # --- Connect classes inheriting from BaseSiteComponent ---
 
     def _make_linked_object(self, identificator_name, identificator, Class, NotFoundException):
         """
-        The Session class doesn't save the login in a ._session attribut, but IS the login ITSELF.
+        The Session class doesn't save the login in a ._session attribute, but IS the login ITSELF.
 
         Therefore the _make_linked_object method has to be adjusted
         to get it to work for in the Session class.
@@ -536,7 +537,7 @@ class Session(BaseSiteComponent):
         return commons._get_object(identificator_name, identificator, Class, NotFoundException, self)
 
 
-    def connect_user(self, username):
+    def connect_user(self, username) -> 'user.User':
         """
         Gets a user using this session, connects the session to the User object to allow authenticated actions
 
@@ -664,7 +665,7 @@ sess
 
         Args:
             category_id (str): ID of the forum category
-        
+
         Keyword Arguments:
             page (str): Page of the category topics that should be returned
 
@@ -714,10 +715,10 @@ sess
 
     def connect_filterbot(self, *, log_deletions=True):
         return filterbot.Filterbot(user.User(username=self.username, _session=self), log_deletions=log_deletions)
-        
+
 # ------ #
 
-def login_by_id(session_id, *, username=None, password=None, xtoken=None):
+def login_by_id(session_id, *, username=None, password=None, xtoken=None) -> Session:
     """
     Creates a session / log in to the Scratch website with the specified session id.
     Structured similarly to Session._connect_object method.
@@ -754,7 +755,7 @@ def login_by_id(session_id, *, username=None, password=None, xtoken=None):
             print(f"Warning: Logged in by id, but couldn't fetch session info. This won't affect any other features.")
     return _session
 
-def login(username, password, *, timeout=10):
+def login(username, password, *, timeout=10) -> Session:
     """
     Creates a session / log in to the Scratch website with the specified username and password.
 

--- a/scratchattach/site/user.py
+++ b/scratchattach/site/user.py
@@ -274,7 +274,7 @@ class User(BaseSiteComponent):
             p["author"] = {"username":self.username}
         return commons.parse_object_list(_projects, project.Project, self._session)
 
-    def loves(self, *, limit=40, offset=0, get_full_project: bool=False) -> [project.Project]:
+    def loves(self, *, limit=40, offset=0, get_full_project: bool = False) -> list[project.Project]:
         """
         Returns:
             list<projects.projects.Project>: The user's loved projects

--- a/scratchattach/site/user.py
+++ b/scratchattach/site/user.py
@@ -286,7 +286,7 @@ class User(BaseSiteComponent):
             raise exceptions.BadRequest("limit parameter must be >= 0")
 
         # There are 40 projects on display per page
-        # So number of pages to view the limit is ceil(limit / 40)
+        # So number of pages to view until the limit is ceil(limit / 40)
 
         # The first page you need to view is 1 + offset // 40
         # (You have to add one because the first page is idx 1 instead of 0)

--- a/scratchattach/site/user.py
+++ b/scratchattach/site/user.py
@@ -286,15 +286,20 @@ class User(BaseSiteComponent):
             raise exceptions.BadRequest("limit parameter must be >= 0")
 
         # There are 40 projects on display per page
-        # So number of pages to view until the limit is ceil(limit / 40)
-
-        # The first page you need to view is 1 + offset // 40
+        # So the first page you need to view is 1 + offset // 40
         # (You have to add one because the first page is idx 1 instead of 0)
+
+        # The final project to view is at idx offset + limit - 1
+        # (You have to -1 because the index starts at 0)
+        # So the page number for this is 1 + (offset + limit - 1) // 40
+
+        # But this is a range so we have to add another 1 for the second argument
         pages = range(1 + offset // 40,
-                      1 + offset // 40 + math.ceil(limit / 40))
+                      2 + (offset + limit - 1) // 40)
         _projects = []
 
         for page in pages:
+            print(f"Requesting p {page}")
             # The index of the first project on page #n is just (n-1) * 40
             first_idx = (page - 1) * 40
 

--- a/scratchattach/site/user.py
+++ b/scratchattach/site/user.py
@@ -3,7 +3,6 @@
 import json
 import random
 import string
-import math
 
 from ..eventhandlers import message_events
 from . import project

--- a/scratchattach/site/user.py
+++ b/scratchattach/site/user.py
@@ -375,6 +375,13 @@ class User(BaseSiteComponent):
             headers=self._headers
         ).text
 
+        # If there are no loved projects, then Scratch doesn't actually display the number - so we have to catch this
+        soup = BeautifulSoup(text, "html.parser")
+
+        if not soup.find("li", {"class": "project thumb item"}):
+            # There are no projects, so there are no projects loved
+            return 0
+
         return commons.webscrape_count(text, "&raquo;\n\n (", ")")
 
     def favorites(self, *, limit=40, offset=0):

--- a/scratchattach/site/user.py
+++ b/scratchattach/site/user.py
@@ -299,7 +299,6 @@ class User(BaseSiteComponent):
         _projects = []
 
         for page in pages:
-            print(f"Requesting p {page}")
             # The index of the first project on page #n is just (n-1) * 40
             first_idx = (page - 1) * 40
 


### PR DESCRIPTION
The scratch API does not provide an endpoint to fetch the list of projects loved by a given user. However, the scratch website does actually have a hidden link that displays the list of projects loved by a user as well as the number of projects loved by said user: `https://scratch.mit.edu/projects/all/<user>/loves/`
This is most likely a legacy feature from an earlier version of the scratch website.

This pull requests introduces the `User.loves()` and `User.loves_count()` functions that webscrape this page and return a list of project objects and the number of loved projects respectively.

**NOTE**: Since the webpage only provides some of the detail for the projects compared to the detail provided by the API for projects, so the Project objects that are instantiated contain less detail. 
The parameter `get_full_project` can be set to True to make a web request for each project to fully instantiate it, using the `Project.update()` function.