### PR TITLE
Typos - .json instead of .sb3

### DIFF
--- a/scratchattach/other/other_apis.py
+++ b/scratchattach/other/other_apis.py
@@ -101,13 +101,3 @@ def aprilfools_get_counter() -> int:
 
 def aprilfools_increment_counter() -> int:
     return requests.post("https://api.scratch.mit.edu/surprise")["surprise"]
-
-# --- Miscellaneous ---
-
-# I'm not sure what to label this as
-def scratch_team_members() -> dict:
-    text = requests.get("https://scratch.mit.edu/js/credits.bundle.js").text
-    text = "[{\"userName\"" + text.split("('[{\"userName\"")[1]
-    text = text.split( "\"}]')")[0] + "\"}]"
-
-    return json.loads(text)

--- a/scratchattach/other/other_apis.py
+++ b/scratchattach/other/other_apis.py
@@ -2,6 +2,7 @@
 
 from ..utils import commons
 from ..utils.requests import Requests as requests
+import json
 
 # --- Front page ---
 
@@ -100,3 +101,13 @@ def aprilfools_get_counter() -> int:
 
 def aprilfools_increment_counter() -> int:
     return requests.post("https://api.scratch.mit.edu/surprise")["surprise"]
+
+# --- Miscellaneous ---
+
+# I'm not sure what to label this as
+def scratch_team_members() -> dict:
+    text = requests.get("https://scratch.mit.edu/js/credits.bundle.js").text
+    text = "[{\"userName\"" + text.split("('[{\"userName\"")[1]
+    text = text.split( "\"}]')")[0] + "\"}]"
+
+    return json.loads(text)

--- a/scratchattach/site/project.py
+++ b/scratchattach/site/project.py
@@ -250,8 +250,8 @@ class Project(PartialProject):
                 f"https://projects.scratch.mit.edu/{self.id}?token={self.project_token}",
                 timeout=10,
             )
-            filename = filename.replace(".sb3", "")
-            open(f"{dir}{filename}.sb3", "wb").write(response.content)
+            filename = filename.replace(".json", "")
+            open(f"{dir}{filename}.json", "wb").write(response.content)
         except Exception:
             raise (
                 exceptions.FetchError(

--- a/scratchattach/site/session.py
+++ b/scratchattach/site/session.py
@@ -536,7 +536,7 @@ class Session(BaseSiteComponent):
         return commons._get_object(identificator_name, identificator, Class, NotFoundException, self)
 
 
-    def connect_user(self, username):
+    def connect_user(self, username) -> 'user.User':
         """
         Gets a user using this session, connects the session to the User object to allow authenticated actions
 
@@ -717,7 +717,7 @@ sess
         
 # ------ #
 
-def login_by_id(session_id, *, username=None, password=None, xtoken=None):
+def login_by_id(session_id, *, username=None, password=None, xtoken=None) -> Session:
     """
     Creates a session / log in to the Scratch website with the specified session id.
     Structured similarly to Session._connect_object method.
@@ -754,7 +754,7 @@ def login_by_id(session_id, *, username=None, password=None, xtoken=None):
             print(f"Warning: Logged in by id, but couldn't fetch session info. This won't affect any other features.")
     return _session
 
-def login(username, password, *, timeout=10):
+def login(username, password, *, timeout=10) -> Session:
     """
     Creates a session / log in to the Scratch website with the specified username and password.
 

--- a/scratchattach/site/session.py
+++ b/scratchattach/site/session.py
@@ -352,7 +352,7 @@ class Session(BaseSiteComponent):
 
         Warning:
             Don't spam this method - it WILL get you banned from Scratch.
-            To prevendfvt accidental spam, a rate limit (5 projects per minute) is implemented for this function.
+            To prevent accidental spam, a rate limit (5 projects per minute) is implemented for this function.
         """
         global CREATE_PROJECT_USES
         if len(CREATE_PROJECT_USES) < 5:


### PR DESCRIPTION
This pull request fixes a typo in the `Session,create_project()` docstring and corrects the `Project.download()` function's filepath to have an extension of `.json` instead of `.sb3`, as it only downloads the `project.json` file, not the whole `.sb3` file with all of the assets. 