### PR TITLE
Pop download_url from return_data of ProjectBody Asset

### DIFF
--- a/scratchattach/other/project_json_capabilities.py
+++ b/scratchattach/other/project_json_capabilities.py
@@ -381,6 +381,7 @@ class ProjectBody:
             return_data = dict(self.__dict__)
             return_data.pop("filename")
             return_data.pop("id")
+            return_data.pop("download_url")
             return return_data
 
         def download(self, *, filename=None, dir=""):


### PR DESCRIPTION
A `ProjectBody` `Asset` sets `self.download_url` in the `from_json` function. The `to_json` function didn't remove this from `return_data`. It doesn't cause any problems, but since `filename` and `id` are removed, `download_url` should also be removed.