### PR TITLE
Settings abilities + small features

### DIFF
--- a/scratchattach/__init__.py
+++ b/scratchattach/__init__.py
@@ -15,7 +15,7 @@ from .site.activity import Activity
 from .site.backpack_asset import BackpackAsset
 from .site.comment import Comment
 from .site.cloud_activity import CloudActivity
-from .site.forum import ForumPost, ForumTopic, get_topic, get_topic_list
+from .site.forum import ForumPost, ForumTopic, get_topic, get_topic_list, youtube_link_to_scratch
 from .site.project import Project, get_project, search_projects, explore_projects
 from .site.session import Session, login, login_by_id, login_by_session_string
 from .site.studio import Studio, get_studio, search_studios, explore_studios

--- a/scratchattach/other/other_apis.py
+++ b/scratchattach/other/other_apis.py
@@ -101,3 +101,17 @@ def aprilfools_get_counter() -> int:
 
 def aprilfools_increment_counter() -> int:
     return requests.post("https://api.scratch.mit.edu/surprise").json()["surprise"]
+
+# --- Resources ---
+def get_resource_urls():
+    return requests.get("https://resources.scratch.mit.edu/localized-urls.json").json()
+
+# --- Misc ---
+# I'm not sure what to label this as
+def scratch_team_members() -> dict:
+    # Unfortunately, the only place to find this is a js file, not a json file, which is annoying
+    text = requests.get("https://scratch.mit.edu/js/credits.bundle.js").text
+    text = "[{\"userName\"" + text.split("JSON.parse('[{\"userName\"")[1]
+    text = text.split("\"}]')")[0] + "\"}]"
+
+    return json.loads(text)

--- a/scratchattach/site/forum.py
+++ b/scratchattach/site/forum.py
@@ -6,6 +6,7 @@ from ..utils import exceptions, commons
 from ._base import BaseSiteComponent
 import xml.etree.ElementTree as ET
 from bs4 import BeautifulSoup
+from urllib.parse import urlparse, parse_qs
 
 from ..utils.requests import Requests as requests
 
@@ -383,3 +384,16 @@ def get_topic_list(category_id, *, page=1):
     except Exception as e:
         raise exceptions.ScrapeError(str(e))
 
+
+def youtube_link_to_scratch(link: str):
+    """
+    Converts a YouTube url (in multiple formats) like https://youtu.be/1JTgg4WVAX8?si=fIEskaEaOIRZyTAz
+    to a link like https://scratch.mit.edu/discuss/youtube/1JTgg4WVAX8
+    """
+    url_parse = urlparse(link)
+    query_parse = parse_qs(url_parse.query)
+    if 'v' in query_parse:
+        video_id = query_parse['v'][0]
+    else:
+        video_id = url_parse.path.split('/')[-1]
+    return f"https://scratch.mit.edu/discuss/youtube/{video_id}"

--- a/scratchattach/site/project.py
+++ b/scratchattach/site/project.py
@@ -100,6 +100,14 @@ class PartialProject(BaseSiteComponent):
             return False
         return True
 
+    @property
+    def embed_url(self):
+        """
+        Returns:
+             the url of the embed of the project
+        """
+        return f"{self.url}/embed"
+
     def remixes(self, *, limit=40, offset=0):
         """
         Returns:

--- a/scratchattach/site/session.py
+++ b/scratchattach/site/session.py
@@ -148,8 +148,8 @@ class Session(BaseSiteComponent):
         Keyword arguments:
             password (str): Password associated with the session (not stored)
         """
-        requests.post("https://scratch.mit.edu/accounts/password_change/",
-                      data={"email_address": self.email,
+        requests.post("https://scratch.mit.edu/accounts/email_change/",
+                      data={"email_address": self.new_email_address,
                             "password": password},
                       headers=self._headers, cookies=self._cookies)
 
@@ -169,7 +169,7 @@ class Session(BaseSiteComponent):
     @property
     def new_email_address(self) -> str | None:
         """
-        Gets the (unconfirmed) email address that this session has requested to transfer to, if any
+        Gets the (unconfirmed) email address that this session has requested to transfer to, if any, otherwise the current address.
 
         Returns:
             str: The email that this session wants to switch to
@@ -178,14 +178,15 @@ class Session(BaseSiteComponent):
                                 headers=self._headers, cookies=self._cookies)
 
         soup = BeautifulSoup(response.content, "html.parser")
+
+        email = None
         for label_span in soup.find_all("span", {"class": "label"}):
             if label_span.contents[0] == "New Email Address":
                 return label_span.parent.contents[-1].text.strip("\n ")
+            elif label_span.contents[0] == "Current Email Address":
+                email = label_span.parent.contents[-1].text.strip("\n ")
 
-        return None
-
-
-
+        return email
 
     def delete_account(self, *, password: str, delete_projects: bool = False):
         """

--- a/scratchattach/site/session.py
+++ b/scratchattach/site/session.py
@@ -82,16 +82,28 @@ class Session(BaseSiteComponent):
         }
 
     def _update_from_dict(self, data):
+        # Note: there are a lot more things you can get from this data dict.
+        # Maybe it would be a good idea to also store the dict itself?
+        # self.data = data
+
         self.xtoken = data['user']['token']
         self._headers["X-Token"] = self.xtoken
+
+        self.has_outstanding_email_confirmation = data["flags"]["has_outstanding_email_confirmation"]
+
         self.email = data["user"]["email"]
+
         self.new_scratcher = data["permissions"]["new_scratcher"]
         self.mute_status = data["permissions"]["mute_status"]
+
         self.username = data["user"]["username"]
         self._username = data["user"]["username"]
         self.banned = data["user"]["banned"]
+
         if self.banned:
             warnings.warn(f"Warning: The account {self._username} you logged in to is BANNED. Some features may not work properly.")
+        if self.has_outstanding_email_confirmation:
+            warnings.warn(f"Warning: The account {self._username} you logged is not email confirmed. Some features may not work properly.")
         return True
 
     def connect_linked_user(self):

--- a/scratchattach/site/session.py
+++ b/scratchattach/site/session.py
@@ -124,6 +124,11 @@ class Session(BaseSiteComponent):
         # backwards compatibility with v1
         return self.connect_linked_user() # To avoid inconsistencies with "connect" and "get", this function was renamed
 
+    def set_country(self, country: str="Antarctica"):
+        requests.post("https://scratch.mit.edu/accounts/settings/",
+                      data={"country": country},
+                      headers=self._headers, cookies=self._cookies)
+
     def delete_account(self, *, password: str, delete_projects: bool = False):
         """
         !!! Dangerous !!!

--- a/scratchattach/site/session.py
+++ b/scratchattach/site/session.py
@@ -129,6 +129,16 @@ class Session(BaseSiteComponent):
                       data={"country": country},
                       headers=self._headers, cookies=self._cookies)
 
+    def change_password(self, old_password: str, new_password: str = None):
+        if new_password is None or new_password == old_password:
+            return
+        requests.post("https://scratch.mit.edu/accounts/password_change/",
+                      data={"old_password": old_password,
+                            "new_password1": new_password,
+                            "new_password2": new_password},
+                      headers=self._headers, cookies=self._cookies)
+
+
     def delete_account(self, *, password: str, delete_projects: bool = False):
         """
         !!! Dangerous !!!

--- a/scratchattach/site/session.py
+++ b/scratchattach/site/session.py
@@ -1,29 +1,32 @@
 """Session class and login function"""
 
-import base64
-import hashlib
 import json
-import pathlib
-import random
 import re
-import time
 import warnings
+import pathlib
+import hashlib
+import time
+import random
+import base64
+import secrets
 from typing import Type
+import zipfile
 
-from bs4 import BeautifulSoup
-
-from . import activity
-from . import classroom
 from . import forum
-from . import studio
-from . import user, project, backpack_asset
-from ._base import BaseSiteComponent
-from ..cloud import cloud, _base
-from ..eventhandlers import message_events, filterbot
-from ..other import project_json_capabilities
+
 from ..utils import commons
+
+from ..cloud import cloud, _base
+from . import user, project, backpack_asset, classroom
 from ..utils import exceptions
+from . import studio
+from . import classroom
+from ..eventhandlers import message_events, filterbot
+from . import activity
+from ._base import BaseSiteComponent
 from ..utils.commons import headers, empty_project_json
+from bs4 import BeautifulSoup
+from ..other import project_json_capabilities
 from ..utils.requests import Requests as requests
 
 CREATE_PROJECT_USES = []

--- a/scratchattach/site/session.py
+++ b/scratchattach/site/session.py
@@ -138,6 +138,51 @@ class Session(BaseSiteComponent):
                             "new_password2": new_password},
                       headers=self._headers, cookies=self._cookies)
 
+    def resend_email(self, password: str):
+        """
+        Sends a request to resend a confirmation email for this session's account
+
+        Keyword arguments:
+            password (str): Password associated with the session (not stored)
+        """
+        requests.post("https://scratch.mit.edu/accounts/password_change/",
+                      data={"email_address": self.email,
+                            "password": password},
+                      headers=self._headers, cookies=self._cookies)
+
+    def change_email(self, new_email: str, password: str):
+        """
+        Sends a request to change the email of this session
+
+        Keyword arguments:
+            new_email (str): The email you want to switch to
+            password (str): Password associated with the session (not stored)
+        """
+        requests.post("https://scratch.mit.edu/accounts/email_change/",
+                      data={"email_address": new_email,
+                            "password": password},
+                      headers=self._headers, cookies=self._cookies)
+
+    @property
+    def new_email_address(self) -> str | None:
+        """
+        Gets the (unconfirmed) email address that this session has requested to transfer to, if any
+
+        Returns:
+            str: The email that this session wants to switch to
+        """
+        response = requests.get("https://scratch.mit.edu/accounts/email_change/",
+                                headers=self._headers, cookies=self._cookies)
+
+        soup = BeautifulSoup(response.content, "html.parser")
+        for label_span in soup.find_all("span", {"class": "label"}):
+            if label_span.contents[0] == "New Email Address":
+                return label_span.parent.contents[-1].text.strip("\n ")
+
+        return None
+
+
+
 
     def delete_account(self, *, password: str, delete_projects: bool = False):
         """

--- a/scratchattach/site/session.py
+++ b/scratchattach/site/session.py
@@ -200,6 +200,13 @@ class Session(BaseSiteComponent):
                           "password": password
                       }, headers=self._headers, cookies=self._cookies)
 
+    def logout(self):
+        """
+        Sends a logout request to scratch. Might not do anything, might log out this account on other ips/sessions? I am not sure
+        """
+        requests.post("https://scratch.mit.edu/accounts/logout/",
+                      headers=self._headers, cookies=self._cookies)
+
     def messages(self, *, limit=40, offset=0, date_limit=None, filter_by=None):
         '''
         Returns the messages.


### PR DESCRIPTION
# Settings abilities
(small features list below)
I found the post endpoints for the account settings menu. All of these features are part of the ```session.Session``` class

---

### Deleting accounts
You can delete an account by providing a delete mode and password (with cookies ofc) though [```https://scratch.mit.edu/accounts/settings/delete_account/```](https://scratch.mit.edu/accounts/settings/delete_account/). The deletion will be cancelled if you log back in on scratch or using the login function in scratchattach. I have not tested logging in by sessionid for this.
NOTE: Joining, however, requires selenium (afaik) since you have to generate a g-recaptcha-code. It would be a feature of [scralenium, a branch of scratchattach](https://github.com/FAReTek1/scratchattach/tree/scralenium) - but note that it's very much WIP since I can't use GitHub entirely properly lol

### Setting your country
You can post at [```https://scratch.mit.edu/accounts/settings/```](https://scratch.mit.edu/accounts/settings/) to change the country of the account that the session is associated with. 

### Changing your password
You can post at [```https://scratch.mit.edu/accounts/password_change/```](https://scratch.mit.edu/accounts/password_change/) to change your password, using the old password and the new password. You will have to enter the old password yourself since the session object does not store the password.

### Logging out
Added a method of ```session.Session``` to send a logout request to scratch. This may not have any effect, although Scratch calls this url whenever you click 'Sign out'. The url [```https://scratch.mit.edu/accounts/logout/```](https://scratch.mit.edu/accounts/logout/)

### Email functionalities
- #### Resending emails
You can ask to resend the email confirmation email as long as you have your password at [```https://scratch.mit.edu/accounts/email_change/```](https://scratch.mit.edu/accounts/email_change/). *NOTE: Since I didn't want to make a new account, this feature has not properly been tested!*
- #### Changing emails
You can change your email provided your password at [```https://scratch.mit.edu/accounts/email_change/```](https://scratch.mit.edu/accounts/email_change/). 
- #### New email address
There is now a bs4-powered property to fetch the (possibly unconfirmed) email address that the session has requested to transfer to, i.e., if there is no unconfirmed email, it returns the current email (NOTE: The defaulting here hasn't been tested!). It reads this by sending a GET request to [```https://scratch.mit.edu/accounts/email_change/```](https://scratch.mit.edu/accounts/email_change/).

# Small features

### YouTube link to scratch link
I often forget the exact URL to the scratch YouTube area so I made a function using urllib (part of the standard library) to parse a youtube url, allowing a few formats to cleanly convert it to a link to the form: [```https://scratch.mit.edu/discuss/youtube/<video id>/```](https://scratch.mit.edu/discuss/youtube/dQw4w9WgXcQ/)

This adds 1 function (to site.forum since the url is part of the forums) called ```youtube_link_to_scratch``` and I made __init__.py import it too

### Embed url property
Added a ```@property``` to ```project.Project``` that simply concatenates ```/embed/``` to the end of the project url

### Added outstanding email confirmation check
When a ```Session``` object calls ```_update_from_dict```, there are many attributes that are still left unused (should be added to a new pr). One of these is a check for whether the user has confirmed their email address.

### Resource APIs
I happened to find this json file that contains links to scratch learning resources in different languages: [```https://resources.scratch.mit.edu/localized-urls.json```](https://resources.scratch.mit.edu/localized-urls.json)

 ### Reading ST member data
Reads the json data directly from the source which powers [the credits page](https://scratch.mit.edu/credits), which is the js file: [```https://scratch.mit.edu/js/credits.bundle.js```](https://scratch.mit.edu/js/credits.bundle.js), close to the bottom