### PR TITLE
add type hint

### DIFF
--- a/scratchattach/__init__.py
+++ b/scratchattach/__init__.py
@@ -19,6 +19,6 @@ from .site.forum import ForumPost, ForumTopic, get_topic, get_topic_list, youtub
 from .site.project import Project, get_project, search_projects, explore_projects
 from .site.session import Session, login, login_by_id, login_by_session_string
 from .site.studio import Studio, get_studio, search_studios, explore_studios
-from .site.classroom import Classroom, get_classroom
+from .site.classroom import Classroom, get_classroom, get_classroom_from_token
 from .site.user import User, get_user
 from .site._base import BaseSiteComponent

--- a/scratchattach/other/other_apis.py
+++ b/scratchattach/other/other_apis.py
@@ -6,70 +6,92 @@ import json
 
 # --- Front page ---
 
-def get_news(*, limit=10, offset=0):
+def get_news(*, limit=10, offset=0) -> list:
     return commons.api_iterative("https://api.scratch.mit.edu/news", limit = limit, offset = offset)
 
-def featured_data():
+def featured_data() -> dict[str,list[dict]]:
     return requests.get("https://api.scratch.mit.edu/proxy/featured").json()
 
-def featured_projects():
+def featured_projects() -> list[dict]:
     return featured_data()["community_featured_projects"]
 
-def featured_studios():
+def featured_studios() -> list[dict]:
     return featured_data()["community_featured_studios"]
 
-def top_loved():
+def top_loved() -> list[dict]:
     return featured_data()["community_most_loved_projects"]
 
-def top_remixed():
+def top_remixed() -> list[dict]:
     return featured_data()["community_most_remixed_projects"]
 
-def newest_projects():
+def newest_projects() -> list[dict]:
     return featured_data()["community_newest_projects"]
 
-def curated_projects():
+def curated_projects() -> list[dict]:
     return featured_data()["curator_top_projects"]
 
-def design_studio_projects():
+def design_studio_projects() -> list[dict]:
     return featured_data()["scratch_design_studio"]
 
 # --- Statistics ---
 
-def total_site_stats():
-    data = requests.get("https://scratch.mit.edu/statistics/data/daily/").json()
-    data.pop("_TS")
-    return data
-
-def monthly_site_traffic():
-    data = requests.get("https://scratch.mit.edu/statistics/data/monthly-ga/").json()
-    data.pop("_TS")
-    return data
-
-def country_counts():
-    return requests.get("https://scratch.mit.edu/statistics/data/monthly/").json()["country_distribution"]
-
-def age_distribution():
-    data = requests.get("https://scratch.mit.edu/statistics/data/monthly/").json()["age_distribution_data"][0]["values"]
+def _maping(data) -> dict[int,int]:
     return_data = {}
     for value in data:
         return_data[value["x"]] = value["y"]
     return return_data
 
-def monthly_comment_activity():
-    return requests.get("https://scratch.mit.edu/statistics/data/monthly/").json()["comment_data"]
+def total_site_stats() -> dict:
+    data = requests.get("https://scratch.mit.edu/statistics/data/daily/").json()
+    data.pop("_TS")
+    return data
 
-def monthly_project_shares():
-    return requests.get("https://scratch.mit.edu/statistics/data/monthly/").json()["project_data"]
+def monthly_site_traffic() -> dict:
+    data = requests.get("https://scratch.mit.edu/statistics/data/monthly-ga/").json()
+    data.pop("_TS")
+    return data
 
-def monthly_active_users():
-    return requests.get("https://scratch.mit.edu/statistics/data/monthly/").json()["active_user_data"]
+def country_counts() -> dict[str,int]:
+    return requests.get("https://scratch.mit.edu/statistics/data/monthly/").json()["country_distribution"]
 
-def monthly_activity_trends():
-    return requests.get("https://scratch.mit.edu/statistics/data/monthly/").json()["activity_data"]
+def age_distribution() -> dict[int,int]:
+    data = requests.get("https://scratch.mit.edu/statistics/data/monthly/").json()["age_distribution_data"][0]["values"]
+    return _maping(data)
+
+def monthly_comment_activity() -> dict[str,dict[int,int]]:
+    data = requests.get("https://scratch.mit.edu/statistics/data/monthly/").json()["comment_data"]
+    return_data = {}
+    return_data[data[0]["key"]] = _maping(data[0]["values"]) #project - "Project Comments"
+    return_data[data[1]["key"]] = _maping(data[1]["values"]) #studio - "Studio Comments"
+    return_data[data[2]["key"]] = _maping(data[2]["values"]) #user - "Profile Comments"
+    return return_data
+
+def monthly_project_shares() -> dict[str,dict[int,int]]:
+    data =  requests.get("https://scratch.mit.edu/statistics/data/monthly/").json()["project_data"]
+    return_data = {}
+    return_data[data[0]["key"]] = _maping(data[0]["values"]) #project - "New Projects"
+    return_data[data[1]["key"]] = _maping(data[1]["values"]) #remix - "Remix Projects"
+    return return_data
+
+
+def monthly_active_users() -> dict[str,dict[int,int]]:
+    data = requests.get("https://scratch.mit.edu/statistics/data/monthly/").json()["active_user_data"]
+    return_data = {}
+    return_data[data[0]["key"]] = _maping(data[0]["values"]) #project - "Project Creators"
+    return_data[data[1]["key"]] = _maping(data[1]["values"]) #comment - "Comment Creators"
+    return return_data
+
+def monthly_activity_trends() -> dict[str,dict[int,int]]:
+    data = requests.get("https://scratch.mit.edu/statistics/data/monthly/").json()["activity_data"]
+    return_data = {}
+    return_data[data[0]["key"]] = _maping(data[0]["values"]) #project - "New Projects"
+    return_data[data[1]["key"]] = _maping(data[1]["values"]) #user - "New Users"
+    return_data[data[2]["key"]] = _maping(data[2]["values"]) #comment - "New Comments"
+    return return_data
 
 # --- CSRF Token Generation API ---
 
-def get_csrf_token():
+def get_csrf_token() -> str:
     """
     Generates a scratchcsrftoken using Scratch's API.
 
@@ -82,17 +104,17 @@ def get_csrf_token():
 
 # --- Various other api.scratch.mit.edu API endpoints ---
 
-def get_health():
+def get_health() -> dict:
     return requests.get("https://api.scratch.mit.edu/health").json()
 
 def get_total_project_count() -> int:
     return requests.get("https://api.scratch.mit.edu/projects/count/all").json()["count"]
 
-def check_username(username):
-    return requests.get(f"https://api.scratch.mit.edu/accounts/checkusername/{username}").json()["msg"]
+def check_username(username) -> bool:
+    return requests.get(f"https://api.scratch.mit.edu/accounts/checkusername/{username}").json()["msg"] == "valid username"
 
-def check_password(password):
-    return requests.post("https://api.scratch.mit.edu/accounts/checkpassword/", json={"password":password}).json()["msg"]
+def check_password(password) -> bool:
+    return requests.post("https://api.scratch.mit.edu/accounts/checkpassword/", json={"password":password}).json()["msg"] == "valid password"
 
 # --- April fools endpoints ---
 
@@ -103,7 +125,7 @@ def aprilfools_increment_counter() -> int:
     return requests.post("https://api.scratch.mit.edu/surprise").json()["surprise"]
 
 # --- Resources ---
-def get_resource_urls():
+def get_resource_urls() -> dict:
     return requests.get("https://resources.scratch.mit.edu/localized-urls.json").json()
 
 # --- Misc ---

--- a/scratchattach/site/_base.py
+++ b/scratchattach/site/_base.py
@@ -1,11 +1,12 @@
 from abc import ABC, abstractmethod
+from typing import Any, Literal
 import requests
 from threading import Thread
 from ..utils import exceptions, commons
 
 class BaseSiteComponent(ABC):
 
-    def update(self):
+    def update(self) -> bool | Literal['429']:
         """
         Updates the attributes of the object by performing an API response. Returns True if the update was successful.
         """
@@ -32,12 +33,12 @@ class BaseSiteComponent(ABC):
         """
         pass
 
-    def _assert_auth(self):
+    def _assert_auth(self) -> None:
         if self._session is None:
             raise exceptions.Unauthenticated(
                 "You need to use session.connect_xyz (NOT get_xyz) in order to perform this operation.")
 
-    def _make_linked_object(self, identificator_id, identificator, Class, NotFoundException):
+    def _make_linked_object(self, identificator_id, identificator, Class, NotFoundException) -> Any:
         """
         Internal function for making a linked object (authentication kept) based on an identificator (like a project id or username)
         Class must inherit from BaseSiteComponent

--- a/scratchattach/site/activity.py
+++ b/scratchattach/site/activity.py
@@ -3,6 +3,7 @@
 import json
 import re
 import time
+from typing import Any, Literal
 
 from . import user
 from . import session
@@ -22,10 +23,10 @@ class Activity(BaseSiteComponent):
     Represents a Scratch activity (message or other user page activity)
     '''
 
-    def str(self):
+    def str(self) -> str:
         return str(self.raw)
 
-    def __init__(self, **entries):
+    def __init__(self, **entries) -> None:
 
         # Set attributes every Activity object needs to have:
         self._session = None
@@ -34,16 +35,16 @@ class Activity(BaseSiteComponent):
         # Update attributes from entries dict:
         self.__dict__.update(entries)
 
-    def update():
+    def update() -> Literal[False]:
         print("Warning: Activity objects can't be updated")
         return False # Objects of this type cannot be updated
 
-    def _update_from_dict(self, data):
+    def _update_from_dict(self, data) -> Literal[True]:
         self.raw = data
         self.__dict__.update(data)
         return True
 
-    def _update_from_html(self, data):
+    def _update_from_html(self, data) -> Literal[True]:
 
         self.raw = data
 
@@ -76,13 +77,13 @@ class Activity(BaseSiteComponent):
 
         return True
 
-    def actor(self):
+    def actor(self) -> user.User:
         """
         Returns the user that performed the activity as User object
         """
         return self._make_linked_object("username", self.actor_username, user.User, exceptions.UserNotFound)
 
-    def target(self):
+    def target(self) -> project.Project | project.PartialProject | studio.Studio | user.User | comment.Comment:
         """
         Returns the activity's target (depending on the activity, this is either a User, Project, Studio or Comment object).
         May also return None if the activity type is unknown.

--- a/scratchattach/site/backpack_asset.py
+++ b/scratchattach/site/backpack_asset.py
@@ -1,4 +1,5 @@
 import time
+from typing import Literal
 from ._base import BaseSiteComponent
 from ..utils.requests import Requests as requests
 from ..utils import exceptions
@@ -24,14 +25,14 @@ class BackpackAsset(BaseSiteComponent):
     :.download_url: Link that leads to a file containing the content of the backpack asset
     """
 
-    def __init__(self, **entries):
+    def __init__(self, **entries) -> None:
         # Set attributes every BackpackAsset object needs to have:
         self._session = None
 
         # Update attributes from entries dict:
         self.__dict__.update(entries)
 
-    def update(self):
+    def update(self) -> Literal[False]:
         print("Warning: BackpackAsset objects can't be updated")
         return False # Objects of this type cannot be updated
     
@@ -52,7 +53,7 @@ class BackpackAsset(BaseSiteComponent):
         except Exception: pass
         return True
 
-    def download(self, *, dir=""):
+    def download(self, *, dir="") -> None:
         """
         Downloads the asset content to the given directory. The given filename is equal to the value saved in the .filename attribute.
 
@@ -74,7 +75,7 @@ class BackpackAsset(BaseSiteComponent):
                 )
             )
 
-    def delete(self):
+    def delete(self) -> dict:
         self._assert_auth()
 
         return requests.delete(

--- a/scratchattach/site/classroom.py
+++ b/scratchattach/site/classroom.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Literal
 import requests
 from . import user, session
 from ..utils.commons import api_iterative, headers
@@ -6,7 +7,7 @@ from ..utils import exceptions, commons
 from ._base import BaseSiteComponent
 
 class Classroom(BaseSiteComponent):
-    def __init__(self, **entries):
+    def __init__(self, **entries) -> None:
         # Info on how the .update method has to fetch the data:
         self.update_function = requests.get
         if "id" in entries:
@@ -36,7 +37,7 @@ class Classroom(BaseSiteComponent):
         self._json_headers["accept"] = "application/json"
         self._json_headers["Content-Type"] = "application/json"
 
-    def _update_from_dict(self, classrooms):
+    def _update_from_dict(self, classrooms) -> Literal[True]:
         try: self.id = int(classrooms["id"])
         except Exception: pass
         try: self.title = classrooms["title"]
@@ -53,7 +54,7 @@ class Classroom(BaseSiteComponent):
         except Exception: pass
         return True
     
-    def student_count(self):
+    def student_count(self) -> int:
         # student count
         text = requests.get(
             f"https://scratch.mit.edu/classes/{self.id}/",
@@ -61,7 +62,7 @@ class Classroom(BaseSiteComponent):
         ).text
         return commons.webscrape_count(text, "Students (", ")")
     
-    def student_names(self, *, page=1):
+    def student_names(self, *, page=1) -> list[str]:
         """
         Returns the student on the class.
         
@@ -78,7 +79,7 @@ class Classroom(BaseSiteComponent):
         textlist = [i.split('/">')[0] for i in text.split('        <a href="/users/')[1:]]
         return textlist
     
-    def class_studio_count(self):
+    def class_studio_count(self) -> int:
         # student count
         text = requests.get(
             f"https://scratch.mit.edu/classes/{self.id}/",
@@ -86,7 +87,7 @@ class Classroom(BaseSiteComponent):
         ).text
         return commons.webscrape_count(text, "Class Studios (", ")")
     
-    def class_studio_ids(self, *, page=1):
+    def class_studio_ids(self, *, page=1) -> list[int]:
         """
         Returns the class studio on the class.
         

--- a/scratchattach/site/cloud_activity.py
+++ b/scratchattach/site/cloud_activity.py
@@ -1,4 +1,5 @@
 import time
+from typing import Literal
 from ._base import BaseSiteComponent
 
 class CloudActivity(BaseSiteComponent):
@@ -22,7 +23,7 @@ class CloudActivity(BaseSiteComponent):
     :.cloud: The cloud (as object inheriting from scratchattach.Cloud.BaseCloud) that the cloud activity corresponds to
     """
 
-    def __init__(self, **entries):
+    def __init__(self, **entries) -> None:
         # Set attributes every CloudActivity object needs to have:
         self._session = None
         self.cloud = None
@@ -34,11 +35,11 @@ class CloudActivity(BaseSiteComponent):
         # Update attributes from entries dict:
         self.__dict__.update(entries)
 
-    def update(self):
+    def update(self) -> Literal[False]:
         print("Warning: CloudActivity objects can't be updated")
         return False # Objects of this type cannot be updated
 
-    def __eq__(self, activity2):
+    def __eq__(self, activity2) -> bool:
         # CloudLogEvents needs to check if two activites are equal (to finde new ones), therefore CloudActivity objects need to be comparable
         return self.user == activity2.user and self.type == activity2.type and self.timestamp == activity2.timestamp and self.value == activity2.value and self.name == activity2.name
     
@@ -63,7 +64,7 @@ class CloudActivity(BaseSiteComponent):
         except Exception: pass
         return True
 
-    def load_log_data(self):
+    def load_log_data(self) -> bool:
         if self.cloud is None:
             print("Warning: There aren't cloud logs available for this cloud, therefore the user and exact timestamp can't be loaded")
         else:
@@ -89,7 +90,8 @@ class CloudActivity(BaseSiteComponent):
             return None
         from ..site import user
         from ..utils import exceptions
-        return self._make_linked_object("username", self.username, user.User, exceptions.UserNotFound)
+        _user:user.User = self._make_linked_object("username", self.username, user.User, exceptions.UserNotFound)
+        return _user
 
     def project(self):
         """
@@ -99,5 +101,6 @@ class CloudActivity(BaseSiteComponent):
             return None
         from ..site import project
         from ..utils import exceptions
-        return self._make_linked_object("id", self.cloud.project_id, project.Project, exceptions.ProjectNotFound)
+        _project:project.Project|project.PartialProject = self._make_linked_object("id", self.cloud.project_id, project.Project, exceptions.ProjectNotFound)
+        return _project
 

--- a/scratchattach/site/comment.py
+++ b/scratchattach/site/comment.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+from typing import Literal, Self
 
 from ..utils import commons
 
@@ -23,7 +24,7 @@ class Comment(BaseSiteComponent):
     Represents a Scratch comment (on a profile, studio or project)
     '''
 
-    def str(self):
+    def str(self) -> str:
         return str(self.content)
 
     def __init__(self, **entries):
@@ -42,11 +43,11 @@ class Comment(BaseSiteComponent):
         # Update attributes from entries dict:
         self.__dict__.update(entries)
 
-    def update(self):
+    def update(self) -> Literal[False]:
         print("Warning: Comment objects can't be updated")
         return False # Objects of this type cannot be updated
 
-    def _update_from_dict(self, data):
+    def _update_from_dict(self, data) -> Literal[True]:
         try: self.id = data["id"]
         except Exception: pass
         try: self.parent_id = data["parent_id"]
@@ -73,10 +74,10 @@ class Comment(BaseSiteComponent):
 
     # Methods for getting related entities
 
-    def author(self):
+    def author(self) -> user.User:
         return self._make_linked_object("username", self.author_name, user.User, exceptions.UserNotFound)
 
-    def place(self):
+    def place(self) -> project.Project | project.PartialProject | studio.Studio | user.User:
         """
         Returns the place (the project, profile or studio) where the comment was posted as Project, User, or Studio object.
 
@@ -89,7 +90,7 @@ class Comment(BaseSiteComponent):
         if self.source == "project":
             return self._make_linked_object("id", self.source_id, project.Project, exceptions.UserNotFound)
 
-    def parent_comment(self):
+    def parent_comment(self) -> None | Self:
         if self.parent_id is None:
             return None
         if self.cached_parent_comment is not None:
@@ -104,7 +105,7 @@ class Comment(BaseSiteComponent):
             self.cached_parent_comment = studio.Studio(id=self.source_id, _session=self._session).comment_by_id(self.parent_id)
         return self.cached_parent_comment
     
-    def replies(self, *, use_cache=True, limit=40, offset=0):
+    def replies(self, *, use_cache=True, limit=40, offset=0) -> None | list[Self] :
         """
         Keyword Arguments:
             use_cache (bool): Returns the replies cached on the first reply fetch. This makes it SIGNIFICANTLY faster for profile comments. Warning: For profile comments, the replies are retrieved and cached on object creation.
@@ -122,7 +123,7 @@ class Comment(BaseSiteComponent):
     
     # Methods for dealing with the comment
 
-    def reply(self, content, *, commentee_id=None):
+    def reply(self, content, *, commentee_id=None) -> Self:
         """
         Posts a reply comment to the comment.
         
@@ -161,7 +162,7 @@ class Comment(BaseSiteComponent):
             return studio.Studio(id=self.source_id, _session=self._session).reply_comment(content, parent_id=str(parent_id), commentee_id=commentee_id)
 
 
-    def delete(self):
+    def delete(self) -> None:
         """
         Deletes the comment.
         """
@@ -175,7 +176,7 @@ class Comment(BaseSiteComponent):
         if self.source == "studio":
             studio.Studio(id=self.source_id, _session=self._session).delete_comment(comment_id=self.id)
 
-    def report(self):
+    def report(self) -> None:
         """
         Reports the comment to the Scratch team.
         """

--- a/scratchattach/site/session.py
+++ b/scratchattach/site/session.py
@@ -9,7 +9,7 @@ import time
 import random
 import base64
 import secrets
-from typing import Type
+from typing import Any, Literal, Type
 import zipfile
 
 from . import forum
@@ -53,10 +53,10 @@ class Session(BaseSiteComponent):
     :.banned: Returns True if the associated account is banned
     '''
 
-    def __str__(self):
-        return "Login for account: {self.username}"
+    def __str__(self) -> str:
+        return f"Login for account: {self.username}"
 
-    def __init__(self, **entries):
+    def __init__(self, **entries) -> None:
 
         # Info on how the .update method has to fetch the data:
         self.update_function = requests.post
@@ -84,7 +84,7 @@ class Session(BaseSiteComponent):
             "Content-Type": "application/json",
         }
 
-    def _update_from_dict(self, data):
+    def _update_from_dict(self, data) -> Literal[True]:
         # Note: there are a lot more things you can get from this data dict.
         # Maybe it would be a good idea to also store the dict itself?
         # self.data = data
@@ -109,7 +109,7 @@ class Session(BaseSiteComponent):
             warnings.warn(f"Warning: The account {self._username} you logged is not email confirmed. Some features may not work properly.")
         return True
 
-    def connect_linked_user(self) -> 'user.User':
+    def connect_linked_user(self) -> user.User:
         '''
         Gets the user associated with the log in / session.
 
@@ -123,16 +123,16 @@ class Session(BaseSiteComponent):
             self._user = self.connect_user(self._username)
         return self._user
 
-    def get_linked_user(self):
+    def get_linked_user(self) -> user.User:
         # backwards compatibility with v1
         return self.connect_linked_user() # To avoid inconsistencies with "connect" and "get", this function was renamed
 
-    def set_country(self, country: str="Antarctica"):
+    def set_country(self, country: str="Antarctica") -> None:
         requests.post("https://scratch.mit.edu/accounts/settings/",
                       data={"country": country},
                       headers=self._headers, cookies=self._cookies)
 
-    def resend_email(self, password: str):
+    def resend_email(self, password: str) -> None:
         """
         Sends a request to resend a confirmation email for this session's account
 
@@ -165,14 +165,14 @@ class Session(BaseSiteComponent):
 
         return email
     
-    def logout(self):
+    def logout(self) -> None:
         """
         Sends a logout request to scratch. Might not do anything, might log out this account on other ips/sessions? I am not sure
         """
         requests.post("https://scratch.mit.edu/accounts/logout/",
                       headers=self._headers, cookies=self._cookies)
 
-    def messages(self, *, limit=40, offset=0, date_limit=None, filter_by=None):
+    def messages(self, *, limit=40, offset=0, date_limit=None, filter_by=None) -> list[activity.Activity]:
         '''
         Returns the messages.
 
@@ -194,7 +194,7 @@ class Session(BaseSiteComponent):
         )
         return commons.parse_object_list(data, activity.Activity, self)
 
-    def admin_messages(self, *, limit=40, offset=0):
+    def admin_messages(self, *, limit=40, offset=0) -> list:
         """
         Returns your messages sent by the Scratch team (alerts).
         """
@@ -204,7 +204,7 @@ class Session(BaseSiteComponent):
         )
 
 
-    def clear_messages(self):
+    def clear_messages(self) -> str:
         '''
         Clears all messages.
         '''
@@ -215,7 +215,7 @@ class Session(BaseSiteComponent):
             timeout = 10,
         ).text
 
-    def message_count(self):
+    def message_count(self) -> int:
         '''
         Returns the message count.
 
@@ -231,7 +231,7 @@ class Session(BaseSiteComponent):
 
     # Front-page-related stuff:
 
-    def feed(self, *, limit=20, offset=0, date_limit=None):
+    def feed(self, *, limit=20, offset=0, date_limit=None) -> list[activity.Activity]:
         '''
         Returns the "What's happening" section (frontpage).
 
@@ -247,11 +247,11 @@ class Session(BaseSiteComponent):
         )
         return commons.parse_object_list(data, activity.Activity, self)
 
-    def get_feed(self, *, limit=20, offset=0, date_limit=None):
+    def get_feed(self, *, limit=20, offset=0, date_limit=None) -> list[activity.Activity]:
         # for more consistent names, this method was renamed
         return self.feed(limit=limit, offset=offset, date_limit=date_limit) # for backwards compatibility with v1
 
-    def loved_by_followed_users(self, *, limit=40, offset=0):
+    def loved_by_followed_users(self, *, limit=40, offset=0) -> list[project.Project|project.PartialProject]:
         '''
         Returns the "Projects loved by Scratchers I'm following" section (frontpage).
 
@@ -298,22 +298,22 @@ class Session(BaseSiteComponent):
 
     # -- Project JSON editing capabilities ---
 
-    def connect_empty_project_pb() -> 'project_json_capabilities.ProjectBody':
+    def connect_empty_project_pb() -> project_json_capabilities.ProjectBody:
         pb = project_json_capabilities.ProjectBody()
         pb.from_json(empty_project_json)
         return pb
 
-    def connect_pb_from_dict(project_json:dict) -> 'project_json_capabilities.ProjectBody':
+    def connect_pb_from_dict(project_json:dict) -> project_json_capabilities.ProjectBody:
         pb = project_json_capabilities.ProjectBody()
         pb.from_json(project_json)
         return pb
 
-    def connect_pb_from_file(path_to_file) -> 'project_json_capabilities.ProjectBody':
+    def connect_pb_from_file(path_to_file) -> project_json_capabilities.ProjectBody:
         pb = project_json_capabilities.ProjectBody()
         pb.from_json(project_json_capabilities._load_sb3_file(path_to_file))
         return pb
 
-    def download_asset(asset_id_with_file_ext, *, filename=None, dir=""):
+    def download_asset(asset_id_with_file_ext, *, filename=None, dir="") -> None:
         if not (dir.endswith("/") or dir.endswith("\\")):
             dir = dir+"/"
         try:
@@ -331,7 +331,7 @@ class Session(BaseSiteComponent):
                 )
             )
 
-    def upload_asset(self, asset_content, *, asset_id=None, file_ext=None):
+    def upload_asset(self, asset_content, *, asset_id=None, file_ext=None) -> None:
         data = asset_content if isinstance(asset_content, bytes) else open(asset_content, "rb").read()
 
         if isinstance(asset_content, str):
@@ -351,7 +351,7 @@ class Session(BaseSiteComponent):
 
     # --- Search ---
 
-    def search_projects(self, *, query="", mode="trending", language="en", limit=40, offset=0):
+    def search_projects(self, *, query="", mode="trending", language="en", limit=40, offset=0) -> list[project.Project|project.PartialProject]:
         '''
         Uses the Scratch search to search projects.
 
@@ -369,7 +369,7 @@ class Session(BaseSiteComponent):
             f"https://api.scratch.mit.edu/search/projects", limit=limit, offset=offset, add_params=f"&language={language}&mode={mode}&q={query}")
         return commons.parse_object_list(response, project.Project, self)
 
-    def explore_projects(self, *, query="*", mode="trending", language="en", limit=40, offset=0):
+    def explore_projects(self, *, query="*", mode="trending", language="en", limit=40, offset=0) -> list[project.Project|project.PartialProject]:
         '''
         Gets projects from the explore page.
 
@@ -387,7 +387,7 @@ class Session(BaseSiteComponent):
             f"https://api.scratch.mit.edu/explore/projects", limit=limit, offset=offset, add_params=f"&language={language}&mode={mode}&q={query}")
         return commons.parse_object_list(response, project.Project, self)
 
-    def search_studios(self, *, query="", mode="trending", language="en", limit=40, offset=0):
+    def search_studios(self, *, query="", mode="trending", language="en", limit=40, offset=0) -> list[studio.Studio]:
         if not query:
             raise ValueError("The query can't be empty for search")
         response = commons.api_iterative(
@@ -395,7 +395,7 @@ class Session(BaseSiteComponent):
         return commons.parse_object_list(response, studio.Studio, self)
 
 
-    def explore_studios(self, *, query="", mode="trending", language="en", limit=40, offset=0):
+    def explore_studios(self, *, query="", mode="trending", language="en", limit=40, offset=0) -> list[studio.Studio]:
         if not query:
             raise ValueError("The query can't be empty for explore")
         response = commons.api_iterative(
@@ -405,7 +405,7 @@ class Session(BaseSiteComponent):
 
     # --- Create project API ---
 
-    def create_project(self, *, title=None, project_json=empty_project_json, parent_id=None): # not working
+    def create_project(self, *, title=None, project_json=empty_project_json, parent_id=None) -> project.Project|project.PartialProject: # not working
         """
         Creates a project on the Scratch website.
 
@@ -421,7 +421,6 @@ class Session(BaseSiteComponent):
                 CREATE_PROJECT_USES.pop()
             else:
                 raise exceptions.BadRequest("Rate limit for creating Scratch projects exceeded.\nThis rate limit is enforced by scratchattach, not by the Scratch API.\nFor security reasons, it cannot be turned off.\n\nDon't spam-create projects, it WILL get you banned.")
-                return
             CREATE_PROJECT_USES.insert(0, time.time())
 
         if title is None:
@@ -438,7 +437,7 @@ class Session(BaseSiteComponent):
 
     # --- My stuff page ---
 
-    def mystuff_projects(self, filter_arg="all", *, page=1, sort_by="", descending=True):
+    def mystuff_projects(self, filter_arg="all", *, page=1, sort_by="", descending=True) -> list[project.Project|project.PartialProject]:
         '''
         Gets the projects from the "My stuff" page.
 
@@ -486,7 +485,7 @@ class Session(BaseSiteComponent):
         except Exception:
             raise(exceptions.FetchError)
 
-    def mystuff_studios(self, filter_arg="all", *, page=1, sort_by="", descending=True):
+    def mystuff_studios(self, filter_arg="all", *, page=1, sort_by="", descending=True) -> list[studio.Studio]:
         if descending:
             ascsort = ""
             descsort = sort_by
@@ -521,7 +520,7 @@ class Session(BaseSiteComponent):
             raise(exceptions.FetchError)
 
 
-    def backpack(self,limit=20, offset=0):
+    def backpack(self,limit=20, offset=0) -> list[backpack_asset.BackpackAsset]:
         '''
         Lists the assets that are in the backpack of the user associated with the session.
 
@@ -534,7 +533,7 @@ class Session(BaseSiteComponent):
         )
         return commons.parse_object_list(data, backpack_asset.BackpackAsset, self)
 
-    def delete_from_backpack(self, backpack_asset_id):
+    def delete_from_backpack(self, backpack_asset_id) -> dict:
         '''
         Deletes an asset from the backpack.
 
@@ -544,7 +543,7 @@ class Session(BaseSiteComponent):
         return backpack_asset.BackpackAsset(id=backpack_asset_id, _session=self).delete()
 
 
-    def become_scratcher_invite(self):
+    def become_scratcher_invite(self) -> dict:
         """
         If you are a new Scratcher and have been invited for becoming a Scratcher, this API endpoint will provide more info on the invite.
         """
@@ -567,14 +566,14 @@ class Session(BaseSiteComponent):
         """
         return CloudClass(project_id=project_id, _session=self)
 
-    def connect_scratch_cloud(self, project_id) -> 'cloud.ScratchCloud':
+    def connect_scratch_cloud(self, project_id) -> cloud.ScratchCloud:
         """
         Returns:
             scratchattach.cloud.ScratchCloud: An object representing the Scratch cloud of a project.
         """
         return cloud.ScratchCloud(project_id=project_id, _session=self)
 
-    def connect_tw_cloud(self, project_id, *, purpose="", contact="", cloud_host="wss://clouddata.turbowarp.org") -> 'cloud.TwCloud':
+    def connect_tw_cloud(self, project_id, *, purpose="", contact="", cloud_host="wss://clouddata.turbowarp.org") -> cloud.TwCloud:
         """
         Returns:
             scratchattach.cloud.TwCloud: An object representing the TurboWarp cloud of a project.
@@ -583,7 +582,7 @@ class Session(BaseSiteComponent):
 
     # --- Connect classes inheriting from BaseSiteComponent ---
 
-    def _make_linked_object(self, identificator_name, identificator, Class, NotFoundException):
+    def _make_linked_object(self, identificator_name, identificator, Class, NotFoundException) -> Any:
         """
         The Session class doesn't save the login in a ._session attribute, but IS the login ITSELF.
 
@@ -595,7 +594,7 @@ class Session(BaseSiteComponent):
         return commons._get_object(identificator_name, identificator, Class, NotFoundException, self)
 
 
-    def connect_user(self, username) -> 'user.User':
+    def connect_user(self, username) -> user.User:
         """
         Gets a user using this session, connects the session to the User object to allow authenticated actions
 
@@ -607,7 +606,7 @@ class Session(BaseSiteComponent):
         """
         return self._make_linked_object("username", username, user.User, exceptions.UserNotFound)
 
-    def find_username_from_id(self, user_id:int):
+    def find_username_from_id(self, user_id:int) -> str:
         """
         Warning:
             Every time this functions is run, a comment on your profile is posted and deleted. Therefore you shouldn't run this too often.
@@ -633,7 +632,7 @@ class Session(BaseSiteComponent):
         return username
 
 
-    def connect_user_by_id(self, user_id:int) -> 'user.User':
+    def connect_user_by_id(self, user_id:int) -> user.User:
         """
         Gets a user using this session, connects the session to the User object to allow authenticated actions
 
@@ -653,7 +652,7 @@ class Session(BaseSiteComponent):
         """
         return self._make_linked_object("username", self.find_username_from_id(user_id), user.User, exceptions.UserNotFound)
 
-    def connect_project(self, project_id) -> 'project.Project':
+    def connect_project(self, project_id) -> project.Project:
         """
         Gets a project using this session, connects the session to the Project object to allow authenticated actions
 sess
@@ -665,7 +664,7 @@ sess
         """
         return self._make_linked_object("id", int(project_id), project.Project, exceptions.ProjectNotFound)
 
-    def connect_studio(self, studio_id) -> 'studio.Studio':
+    def connect_studio(self, studio_id) -> studio.Studio:
         """
         Gets a studio using this session, connects the session to the Studio object to allow authenticated actions
 
@@ -677,7 +676,7 @@ sess
         """
         return self._make_linked_object("id", int(studio_id), studio.Studio, exceptions.StudioNotFound)
 
-    def connect_classroom(self, class_id) -> 'classroom.Classroom':
+    def connect_classroom(self, class_id) -> classroom.Classroom:
         """
         Gets a class using this session.
 
@@ -689,7 +688,7 @@ sess
         """
         return self._make_linked_object("id", int(class_id), classroom.Classroom, exceptions.ClassroomNotFound)
 
-    def connect_classroom_from_token(self, class_token) -> 'classroom.Classroom':
+    def connect_classroom_from_token(self, class_token) -> classroom.Classroom:
         """
         Gets a class using this session.
 
@@ -701,7 +700,7 @@ sess
         """
         return self._make_linked_object("classtoken", int(class_token), classroom.Classroom, exceptions.ClassroomNotFound)
 
-    def connect_topic(self, topic_id) -> 'forum.ForumTopic':
+    def connect_topic(self, topic_id) -> forum.ForumTopic:
         """
         Gets a forum topic using this session, connects the session to the ForumTopic object to allow authenticated actions
         Data is up-to-date. Data received from Scratch's RSS feed XML API.
@@ -715,7 +714,7 @@ sess
         return self._make_linked_object("id", int(topic_id), forum.ForumTopic, exceptions.ForumContentNotFound)
 
 
-    def connect_topic_list(self, category_id, *, page=1):
+    def connect_topic_list(self, category_id, *, page=1) -> list[forum.ForumTopic]:
 
         """
         Gets the topics from a forum category. Data web-scraped from Scratch's forums UI.
@@ -767,11 +766,11 @@ sess
 
     # --- Connect classes inheriting from BaseEventHandler ---
 
-    def connect_message_events(self, *, update_interval=2) -> 'message_events.MessageEvents':
+    def connect_message_events(self, *, update_interval=2) -> message_events.MessageEvents:
         # shortcut for connect_linked_user().message_events()
         return message_events.MessageEvents(user.User(username=self.username, _session=self), update_interval=update_interval)
 
-    def connect_filterbot(self, *, log_deletions=True) -> 'filterbot.Filterbot':
+    def connect_filterbot(self, *, log_deletions=True) -> filterbot.Filterbot:
         return filterbot.Filterbot(user.User(username=self.username, _session=self), log_deletions=log_deletions)
 
 # ------ #

--- a/scratchattach/site/studio.py
+++ b/scratchattach/site/studio.py
@@ -2,6 +2,7 @@
 
 import json
 import random
+from typing import Literal
 from . import user, comment, project, activity
 from ..utils import exceptions, commons
 from ..utils.commons import api_iterative, headers
@@ -43,7 +44,7 @@ class Studio(BaseSiteComponent):
 
     """
 
-    def __init__(self, **entries):
+    def __init__(self, **entries) -> None:
 
         # Info on how the .update method has to fetch the data:
         self.update_function = requests.get
@@ -69,7 +70,7 @@ class Studio(BaseSiteComponent):
         self._json_headers["accept"] = "application/json"
         self._json_headers["Content-Type"] = "application/json"
 
-    def _update_from_dict(self, studio):
+    def _update_from_dict(self, studio) -> Literal[True]:
         try: self.id = int(studio["id"])
         except Exception: pass
         try: self.title = studio["title"]
@@ -96,7 +97,7 @@ class Studio(BaseSiteComponent):
         except Exception: pass
         return True
 
-    def follow(self):
+    def follow(self) -> None:
         """
         You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_studio`
         """
@@ -108,7 +109,7 @@ class Studio(BaseSiteComponent):
             timeout=10,
         )
 
-    def unfollow(self):
+    def unfollow(self) -> None:
         """
         You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_studio`
         """
@@ -120,7 +121,7 @@ class Studio(BaseSiteComponent):
             timeout=10,
         )
 
-    def comments(self, *, limit=40, offset=0):
+    def comments(self, *, limit=40, offset=0) -> list[comment.Comment]:
         """
         Returns the comments posted on the studio (except for replies. To get replies use :meth:`scratchattach.studio.Studio.get_comment_replies`).
 
@@ -138,7 +139,7 @@ class Studio(BaseSiteComponent):
             i["source_id"] = self.id
         return commons.parse_object_list(response, comment.Comment, self._session)
 
-    def comment_replies(self, *, comment_id, limit=40, offset=0):
+    def comment_replies(self, *, comment_id, limit=40, offset=0) -> list[comment.Comment]:
         response = commons.api_iterative(
             f"https://api.scratch.mit.edu/studios/{self.id}/comments/{comment_id}/replies", limit=limit, offset=offset, add_params=f"&cachebust={random.randint(0,9999)}")
         for x in response:
@@ -147,7 +148,7 @@ class Studio(BaseSiteComponent):
             x["source_id"] = self.id    
         return commons.parse_object_list(response, comment.Comment, self._session)
 
-    def comment_by_id(self, comment_id):
+    def comment_by_id(self, comment_id) -> comment.Comment:
         r = requests.get(
             f"https://api.scratch.mit.edu/studios/{self.id}/comments/{comment_id}",
             timeout=10,
@@ -158,7 +159,7 @@ class Studio(BaseSiteComponent):
         _comment._update_from_dict(r)
         return _comment
 
-    def post_comment(self, content, *, parent_id="", commentee_id=""):
+    def post_comment(self, content, *, parent_id="", commentee_id="") -> comment.Comment:
         """
         Posts a comment on the studio. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_studio`
 
@@ -223,7 +224,7 @@ class Studio(BaseSiteComponent):
             cookies=self._cookies,
         )
 
-    def set_thumbnail(self, *, file):
+    def set_thumbnail(self, *, file) -> str:
         """
         Sets the studio thumbnail. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_studio`
 
@@ -268,7 +269,7 @@ class Studio(BaseSiteComponent):
         else:
             return r["thumbnail_url"]
 
-    def reply_comment(self, content, *, parent_id, commentee_id=""):
+    def reply_comment(self, content, *, parent_id, commentee_id="") -> comment.Comment:
         """
         Posts a reply to a comment on the studio. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_studio`
 
@@ -289,7 +290,7 @@ class Studio(BaseSiteComponent):
             content, parent_id=parent_id, commentee_id=commentee_id
         )
 
-    def projects(self, limit=40, offset=0):
+    def projects(self, limit=40, offset=0) -> list[project.Project|project.PartialProject]:
         """
         Gets the studio projects.
 
@@ -304,7 +305,7 @@ class Studio(BaseSiteComponent):
             f"https://api.scratch.mit.edu/studios/{self.id}/projects", limit=limit, offset=offset)
         return commons.parse_object_list(response, project.Project, self._session)
 
-    def curators(self, limit=40, offset=0):
+    def curators(self, limit=40, offset=0) -> list[user.User]:
         """
         Gets the studio curators.
 
@@ -320,7 +321,7 @@ class Studio(BaseSiteComponent):
         return commons.parse_object_list(response, user.User, self._session, "username")
 
 
-    def invite_curator(self, curator):
+    def invite_curator(self, curator) -> dict:
         """
         You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_studio`
         """
@@ -335,7 +336,7 @@ class Studio(BaseSiteComponent):
         except Exception:
             raise (exceptions.Unauthorized)
 
-    def promote_curator(self, curator):
+    def promote_curator(self, curator) -> dict:
         """
         You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_studio`
         """
@@ -350,7 +351,7 @@ class Studio(BaseSiteComponent):
         except Exception:
             raise (exceptions.Unauthorized)
 
-    def remove_curator(self, curator):
+    def remove_curator(self, curator) -> dict:
         """
         You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_studio`
         """
@@ -391,14 +392,14 @@ class Studio(BaseSiteComponent):
             raise (exceptions.Unauthorized)
     
 
-    def leave(self):
+    def leave(self) -> dict:
         """
         Removes yourself from the studio. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_studio`
         """
         self._assert_auth()
         return self.remove_curator(self._session._username)
 
-    def add_project(self, project_id):
+    def add_project(self, project_id) -> dict:
         """
         Adds a project to the studio. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_studio`
 
@@ -412,7 +413,7 @@ class Studio(BaseSiteComponent):
             timeout=10,
         ).json()
 
-    def remove_project(self, project_id):
+    def remove_project(self, project_id) -> dict:
         """
         Removes a project from the studio. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_studio`
 
@@ -426,7 +427,7 @@ class Studio(BaseSiteComponent):
             timeout=10,
         ).json()
 
-    def managers(self, limit=40, offset=0):
+    def managers(self, limit=40, offset=0) -> list[user.User]:
         """
         Gets the studio managers.
 
@@ -441,7 +442,7 @@ class Studio(BaseSiteComponent):
             f"https://api.scratch.mit.edu/studios/{self.id}/managers", limit=limit, offset=offset)
         return commons.parse_object_list(response, user.User, self._session, "username")
 
-    def host(self):
+    def host(self) -> user.User | None:
         """
         Gets the studio host.
 
@@ -454,7 +455,7 @@ class Studio(BaseSiteComponent):
         except Exception:
             return None
 
-    def set_fields(self, fields_dict):
+    def set_fields(self, fields_dict) -> None:
         """
         Sets fields. Uses the scratch.mit.edu/site-api PUT API.
         """
@@ -468,19 +469,19 @@ class Studio(BaseSiteComponent):
         )
 
 
-    def set_description(self, new):
+    def set_description(self, new) -> None:
         """
         You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_studio`
         """
         self.set_fields({"description": new + "\n"})
 
-    def set_title(self, new):
+    def set_title(self, new) -> None:
         """
         You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_studio`
         """
         self.set_fields({"title": new})
 
-    def open_projects(self):
+    def open_projects(self) -> None:
         """
         Changes the studio settings so everyone (including non-curators) is able to add projects to the studio. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_studio`
         """
@@ -492,7 +493,7 @@ class Studio(BaseSiteComponent):
             timeout=10,
         )
 
-    def close_projects(self):
+    def close_projects(self) -> None:
         """
         Changes the studio settings so only curators can add projects to the studio. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_studio`
         """
@@ -504,7 +505,7 @@ class Studio(BaseSiteComponent):
             timeout=10,
         )
 
-    def turn_off_commenting(self):
+    def turn_off_commenting(self) -> None:
         """
         You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_studio`
         """
@@ -518,7 +519,7 @@ class Studio(BaseSiteComponent):
             )
             self.comments_allowed = not self.comments_allowed
 
-    def turn_on_commenting(self):
+    def turn_on_commenting(self) -> None:
         """
         You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_studio`
         """
@@ -532,7 +533,7 @@ class Studio(BaseSiteComponent):
             )
             self.comments_allowed = not self.comments_allowed
 
-    def toggle_commenting(self):
+    def toggle_commenting(self) -> None:
         """
         You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_studio`
         """
@@ -562,7 +563,7 @@ class Studio(BaseSiteComponent):
             timeout=10,
         ).json()
     
-    def your_role(self):
+    def your_role(self) -> dict:
         """
         Returns a dict with information about your role in the studio (whether you're following, curating, managing it or are invited)
         """
@@ -593,7 +594,7 @@ def get_studio(studio_id) -> Studio:
     print("Warning: For methods that require authentication, use session.connect_studio instead of get_studio")
     return commons._get_object("id", studio_id, Studio, exceptions.StudioNotFound)
 
-def search_studios(*, query="", mode="trending", language="en", limit=40, offset=0):
+def search_studios(*, query="", mode="trending", language="en", limit=40, offset=0) -> list[Studio]:
     if not query:
         raise ValueError("The query can't be empty for search")
     response = commons.api_iterative(
@@ -601,7 +602,7 @@ def search_studios(*, query="", mode="trending", language="en", limit=40, offset
     return commons.parse_object_list(response, Studio)
 
 
-def explore_studios(*, query="", mode="trending", language="en", limit=40, offset=0):
+def explore_studios(*, query="", mode="trending", language="en", limit=40, offset=0) -> list[Studio]:
     if not query:
         raise ValueError("The query can't be empty for explore")
     response = commons.api_iterative(

--- a/scratchattach/site/user.py
+++ b/scratchattach/site/user.py
@@ -3,6 +3,7 @@
 import json
 import random
 import string
+from typing import Literal, Self
 
 from ..eventhandlers import message_events
 from . import project
@@ -42,10 +43,10 @@ class User(BaseSiteComponent):
     :.update(): Updates the attributes
     '''
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.username)
 
-    def __init__(self, **entries):
+    def __init__(self, **entries) -> None:
 
         # Info on how the .update method has to fetch the data:
         self.update_function = requests.get
@@ -82,7 +83,7 @@ class User(BaseSiteComponent):
         self._json_headers["accept"] = "application/json"
         self._json_headers["Content-Type"] = "application/json"
 
-    def _update_from_dict(self, data):
+    def _update_from_dict(self, data) -> Literal[True]:
         try: self.id = data["id"]
         except KeyError: pass
         try: self.username = data["username"]
@@ -108,7 +109,7 @@ class User(BaseSiteComponent):
                 "You need to be authenticated as the profile owner to do this.")
 
 
-    def does_exist(self):
+    def does_exist(self) -> None | bool:
         """
         Returns:
             boolean : True if the user exists, False if the user is deleted, None if an error occured
@@ -119,7 +120,7 @@ class User(BaseSiteComponent):
         elif status_code == 404:
             return False
 
-    def is_new_scratcher(self):
+    def is_new_scratcher(self) -> bool | None:
         """
         Returns:
             boolean : True if the user has the New Scratcher status, else False
@@ -131,11 +132,11 @@ class User(BaseSiteComponent):
         except Exception:
             return None
 
-    def message_count(self):
+    def message_count(self) -> int:
 
         return json.loads(requests.get(f"https://api.scratch.mit.edu/users/{self.username}/messages/count/?cachebust={random.randint(0,10000)}", headers = {'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.3c6 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36',}).text)["count"]
 
-    def featured_data(self):
+    def featured_data(self) -> dict | None:
         """
         Returns:
             dict: Gets info on the user's featured project and featured label (like "Featured project", "My favorite things", etc.)
@@ -155,7 +156,7 @@ class User(BaseSiteComponent):
         except Exception:
             return None
 
-    def follower_count(self):
+    def follower_count(self) -> int:
         # follower count
         text = requests.get(
             f"https://scratch.mit.edu/users/{self.username}/followers/",
@@ -163,7 +164,7 @@ class User(BaseSiteComponent):
         ).text
         return commons.webscrape_count(text, "Followers (", ")")
 
-    def following_count(self):
+    def following_count(self) -> int:
         # following count
         text = requests.get(
             f"https://scratch.mit.edu/users/{self.username}/following/",
@@ -171,7 +172,7 @@ class User(BaseSiteComponent):
         ).text
         return commons.webscrape_count(text, "Following (", ")")
 
-    def followers(self, *, limit=40, offset=0):
+    def followers(self, *, limit=40, offset=0) -> list[Self]:
         """
         Returns:
             list<scratchattach.user.User>: The user's followers as list of scratchattach.user.User objects
@@ -180,14 +181,14 @@ class User(BaseSiteComponent):
             f"https://api.scratch.mit.edu/users/{self.username}/followers/", limit=limit, offset=offset)
         return commons.parse_object_list(response, User, self._session, "username")
 
-    def follower_names(self, *, limit=40, offset=0):
+    def follower_names(self, *, limit=40, offset=0) -> list[str]:
         """
         Returns:
             list<str>: The usernames of the user's followers
         """
         return [i.name for i in self.followers(limit=limit, offset=offset)]
 
-    def following(self, *, limit=40, offset=0):
+    def following(self, *, limit=40, offset=0) -> list[Self]:
         """
         Returns:
             list<scratchattach.user.User>: The users that the user is following as list of scratchattach.user.User objects
@@ -196,14 +197,14 @@ class User(BaseSiteComponent):
             f"https://api.scratch.mit.edu/users/{self.username}/following/", limit=limit, offset=offset)
         return commons.parse_object_list(response, User, self._session, "username")
 
-    def following_names(self, *, limit=40, offset=0):
+    def following_names(self, *, limit=40, offset=0) -> list[str]:
         """
         Returns:
             list<str>: The usernames of the users the user is following
         """
         return [i.name for i in self.following(limit=limit, offset=offset)]
 
-    def is_following(self, user):
+    def is_following(self, user) -> bool:
         """
         Returns:
             boolean: Whether the user is following the user provided as argument
@@ -225,35 +226,35 @@ class User(BaseSiteComponent):
                 return following
         return following
 
-    def is_followed_by(self, user):
+    def is_followed_by(self, user) -> bool:
         """
         Returns:
             boolean: Whether the user is followed by the user provided as argument
         """
         return User(username=user).is_following(self.username)
 
-    def project_count(self):
+    def project_count(self) -> int:
         text = requests.get(
             f"https://scratch.mit.edu/users/{self.username}/projects/",
             headers = self._headers
         ).text
         return commons.webscrape_count(text, "Shared Projects (", ")")
 
-    def studio_count(self):
+    def studio_count(self) -> int:
         text = requests.get(
             f"https://scratch.mit.edu/users/{self.username}/studios/",
             headers = self._headers
         ).text
         return commons.webscrape_count(text, "Studios I Curate (", ")")
 
-    def studios_following_count(self):
+    def studios_following_count(self) -> int:
         text = requests.get(
             f"https://scratch.mit.edu/users/{self.username}/studios/",
             headers = self._headers
         ).text
         return commons.webscrape_count(text, "Studios I Follow (", ")")
 
-    def studios(self, *, limit=40, offset=0):
+    def studios(self, *, limit=40, offset=0) -> list[studio.Studio]:
         _studios = commons.api_iterative(
             f"https://api.scratch.mit.edu/users/{self.username}/studios/curate", limit=limit, offset=offset)
         studios = []
@@ -263,7 +264,7 @@ class User(BaseSiteComponent):
             studios.append(_studio)
         return studios
 
-    def projects(self, *, limit=40, offset=0):
+    def projects(self, *, limit=40, offset=0) -> list[project.Project]:
         """
         Returns:
             list<projects.projects.Project>: The user's shared projects
@@ -274,7 +275,7 @@ class User(BaseSiteComponent):
             p["author"] = {"username":self.username}
         return commons.parse_object_list(_projects, project.Project, self._session)
 
-    def loves(self, *, limit=40, offset=0, get_full_project: bool = False) -> list[project.Project]:
+    def loves(self, *, limit=40, offset=0, get_full_project: bool = False) -> list[project.Project|project.PartialProject]:
         """
         Returns:
             list<projects.projects.Project>: The user's loved projects
@@ -370,7 +371,7 @@ class User(BaseSiteComponent):
 
         return _projects
 
-    def loves_count(self):
+    def loves_count(self) -> int:
         text = requests.get(
             f"https://scratch.mit.edu/projects/all/{self.username}/loves/",
             headers=self._headers
@@ -385,7 +386,7 @@ class User(BaseSiteComponent):
 
         return commons.webscrape_count(text, "&raquo;\n\n (", ")")
 
-    def favorites(self, *, limit=40, offset=0):
+    def favorites(self, *, limit=40, offset=0) -> list[project.Project|project.PartialProject]:
         """
         Returns:
             list<projects.projects.Project>: The user's favorite projects
@@ -394,14 +395,14 @@ class User(BaseSiteComponent):
             f"https://api.scratch.mit.edu/users/{self.username}/favorites/", limit=limit, offset=offset, headers = self._headers)
         return commons.parse_object_list(_projects, project.Project, self._session)
 
-    def favorites_count(self):
+    def favorites_count(self) -> int:
         text = requests.get(
             f"https://scratch.mit.edu/users/{self.username}/favorites/",
             headers = self._headers
         ).text
         return commons.webscrape_count(text, "Favorites (", ")")
 
-    def toggle_commenting(self):
+    def toggle_commenting(self) -> None:
         """
         You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_user`
         """
@@ -411,7 +412,7 @@ class User(BaseSiteComponent):
             cookies = self._cookies
         )
 
-    def viewed_projects(self, limit=24, offset=0):
+    def viewed_projects(self, limit=24, offset=0) -> list[project.Project|project.PartialProject]:
         """
         Returns:
             list<projects.projects.Project>: The user's recently viewed projects
@@ -423,7 +424,7 @@ class User(BaseSiteComponent):
             f"https://api.scratch.mit.edu/users/{self.username}/projects/recentlyviewed", limit=limit, offset=offset, headers = self._headers)
         return commons.parse_object_list(_projects, project.Project, self._session)
 
-    def set_bio(self, text):
+    def set_bio(self, text) -> None:
         """
         Sets the user's "About me" section. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_user`
         """
@@ -442,7 +443,7 @@ class User(BaseSiteComponent):
             ))
         )
 
-    def set_wiwo(self, text):
+    def set_wiwo(self, text) -> None:
         """
         Sets the user's "What I'm working on" section. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_user`
         """
@@ -461,7 +462,7 @@ class User(BaseSiteComponent):
             ))
         )
 
-    def set_featured(self, project_id, *, label=""):
+    def set_featured(self, project_id, *, label="") -> None:
         """
         Sets the user's featured project. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_user`
 
@@ -479,7 +480,7 @@ class User(BaseSiteComponent):
             data = json.dumps({"featured_project":int(project_id),"featured_project_label":label})
         )
 
-    def set_forum_signature(self, text):
+    def set_forum_signature(self, text) -> None:
         """
         Sets the user's discuss forum signature. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_user`
         """
@@ -498,7 +499,7 @@ class User(BaseSiteComponent):
         }
         response = requests.post(f'https://scratch.mit.edu/discuss/settings/{self.username}/', cookies=self._cookies, headers=headers, data=data)
 
-    def post_comment(self, content, *, parent_id="", commentee_id=""):
+    def post_comment(self, content, *, parent_id="", commentee_id="") -> comment.Comment:
         """
         Posts a comment on the user's profile. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_user`
 
@@ -549,7 +550,7 @@ class User(BaseSiteComponent):
             else:
                 raise(exceptions.FetchError("Couldn't parse API response"))
 
-    def reply_comment(self, content, *, parent_id, commentee_id=""):
+    def reply_comment(self, content, *, parent_id, commentee_id="") -> comment.Comment:
         """
         Replies to a comment given by its id
 
@@ -567,7 +568,7 @@ class User(BaseSiteComponent):
         """
         return self.post_comment(content, parent_id=parent_id, commentee_id=commentee_id)
 
-    def activity(self, *, limit=1000):
+    def activity(self, *, limit=1000) -> list[activity.Activity]:
         """
         Returns:
             list<scratchattach.Activity>: The user's activity data as parsed list of scratchattach.activity.Activity objects
@@ -585,7 +586,7 @@ class User(BaseSiteComponent):
         return activities
 
 
-    def activity_html(self, *, limit=1000):
+    def activity_html(self, *, limit=1000) -> str:
         """
         Returns:
             str: The raw user activity HTML data
@@ -593,7 +594,7 @@ class User(BaseSiteComponent):
         return requests.get(f"https://scratch.mit.edu/messages/ajax/user-activity/?user={self.username}&max={limit}").text
 
 
-    def follow(self):
+    def follow(self) -> None:
         """
         Follows the user represented by the User object. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_user`
         """
@@ -604,7 +605,7 @@ class User(BaseSiteComponent):
             cookies = self._cookies,
         )
 
-    def unfollow(self):
+    def unfollow(self) -> None:
         """
         Unfollows the user represented by the User object. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_user`
         """
@@ -645,7 +646,7 @@ class User(BaseSiteComponent):
             data = json.dumps({"id":str(comment_id)})
         )
 
-    def comments(self, *, page=1, limit=None):
+    def comments(self, *, page=1, limit=None) -> None | list[comment.Comment]:
         """
         Returns the comments posted on the user's profile (with replies).
 
@@ -713,7 +714,7 @@ class User(BaseSiteComponent):
             DATA.append(_comment)
         return DATA
 
-    def comment_by_id(self, comment_id):
+    def comment_by_id(self, comment_id) -> comment.Comment:
         """
         Gets a comment on this user's profile by id.
 
@@ -738,7 +739,7 @@ class User(BaseSiteComponent):
             page_content = self.comments(page=page)
         raise exceptions.CommentNotFound()
 
-    def message_events(self):
+    def message_events(self) -> message_events.MessageEvents[Self]:
         return message_events.MessageEvents(self)
 
     def stats(self):
@@ -779,7 +780,7 @@ class User(BaseSiteComponent):
         except Exception:
             return {"country":{"loves":0,"favorites":0,"comments":0,"views":0,"followers":0,"following":0},"loves":0,"favorites":0,"comments":0,"views":0,"followers":0,"following":0}
 
-    def ocular_status(self):
+    def ocular_status(self) -> dict:
         """
         Gets information about the user's ocular status. Ocular is a website developed by jeffalo: https://ocular.jeffalo.net/
 

--- a/scratchattach/utils/commons.py
+++ b/scratchattach/utils/commons.py
@@ -1,5 +1,6 @@
 """v2 ready: Common functions used by various internal modules"""
 
+from typing import Any
 from . import exceptions
 from threading import Thread
 from .requests import Requests as requests
@@ -57,7 +58,7 @@ empty_project_json = {
 }
 
 
-def api_iterative_data(fetch_func, limit, offset, max_req_limit=40, unpack=True):
+def api_iterative_data(fetch_func, limit, offset, max_req_limit=40, unpack=True) -> list:
     """
     Iteratively gets data by calling fetch_func with a moving offset and a limit.
     Once fetch_func returns None, the retrieval is completed.
@@ -83,7 +84,7 @@ def api_iterative_data(fetch_func, limit, offset, max_req_limit=40, unpack=True)
 
 def api_iterative(
     url, *, limit, offset, max_req_limit=40, add_params="", headers=headers, cookies={}
-):
+) -> list:
     """
     Function for getting data from one of Scratch's iterative JSON API endpoints (like /users/<user>/followers, or /users/<user>/projects)
     """
@@ -110,7 +111,7 @@ def api_iterative(
     )
     return api_data
 
-def _get_object(identificator_name, identificator, Class, NotFoundException, session=None):
+def _get_object(identificator_name, identificator, Class, NotFoundException, session=None) -> Any:
     # Interal function: Generalization of the process ran by get_user, get_studio etc.
     # Builds an object of class that is inheriting from BaseSiteComponent
     # # Class must inherit from BaseSiteComponent
@@ -133,10 +134,10 @@ def _get_object(identificator_name, identificator, Class, NotFoundException, ses
     except Exception as e:
         raise(e)
 
-def webscrape_count(raw, text_before, text_after):
+def webscrape_count(raw, text_before, text_after) -> int:
     return int(raw.split(text_before)[1].split(text_after)[0])
 
-def parse_object_list(raw, Class, session=None, primary_key="id"):
+def parse_object_list(raw, Class, session=None, primary_key="id") -> list:
     results = []
     for raw_dict in raw:
         try:

--- a/scratchattach/utils/encoder.py
+++ b/scratchattach/utils/encoder.py
@@ -110,7 +110,7 @@ class Encoding:
     Class that contains tools for encoding / decoding strings. The strings encoded / decoded with these functions can be decoded / encoded with Scratch using this sprite: https://scratch3-assets.1tim.repl.co/Encoder.sprite3
     """
     @staticmethod
-    def decode(inp):
+    def decode(inp) -> str:
         """
         Args:
             inp (str): The encoded input.
@@ -129,7 +129,7 @@ class Encoding:
         return outp
 
     @staticmethod
-    def encode(inp):
+    def encode(inp) -> str:
         """
         Args:
             inp (str): The decoded input.
@@ -147,7 +147,7 @@ class Encoding:
         return outp
 
     @staticmethod
-    def replace_char(old_char, new_char):
+    def replace_char(old_char, new_char) -> None:
         """
         Replaces a character in the list that the encoder uses to encode / decode values.
         You can access this list using `scratchattach.encoder.letters`


### PR DESCRIPTION
## ADD type hint

**Where circular imports may occur, we have done the following.**
```py
def func(self):
    from ..site import project
    _project:project.Project|project.PartialProject = self._make_linked_object(...)
    return _project
```

Type hints not added

- delete_comment
- report_comment
- set_json (project)
- transfer_ownership (studio)

=====

- project_json_capabilities
- cloud
- eventhandlers

=====

- ScratchDB api


## others
- `Project.visibility()` To do A we need a project owner.
- `_maping()` (in other_apis.py) Automatic formatting of statistics (`sa.monthly_`)
- Import get_classroom_from_token

**deepl translation**

## JP
### 型ヒントを追加しました。
**循環インポートが発生する場合は、以下の通りで実装しています。**
```py
def func(self):
    from ..site import project
    _project:project.Project|project.PartialProject = self._make_linked_object(...)
    return _project
```
以下の関数、ファイルには追加していません。

- delete_comment
- report_comment
- set_json (project)
- transfer_ownership (studio)

=====

- project_json_capabilities
- cloud
- eventhandlers

=====

- ScratchDB api

### その他
- `Project.visibility()` はプロジェクト所有者を必要としました。
- `sa.monthly_` 系統の自動整形。(`_maping()` (other_apis.py にある)の追加、)
- get_classroom_from_token をimport させるように。