### PR TITLE
Added create_studio + did a little with exceptions + type hints

### DIFF
--- a/scratchattach/cloud/_base.py
+++ b/scratchattach/cloud/_base.py
@@ -100,7 +100,7 @@ class BaseCloud(ABC):
                         self.websocket.send(json.dumps(packet) + "\n")
                     except Exception:
                         self.active_connection = False
-                        raise exceptions.ConnectionError(f"Sending packet failed three times in a row: {packet}")
+                        raise exceptions.CloudConnectionError(f"Sending packet failed three times in a row: {packet}")
 
     def _send_packet_list(self, packet_list):
         packet_string = "".join([json.dumps(packet) + "\n" for packet in packet_list])
@@ -126,7 +126,7 @@ class BaseCloud(ABC):
                         self.websocket.send(packet_string)
                     except Exception:
                         self.active_connection = False
-                        raise exceptions.ConnectionError(f"Sending packet list failed four times in a row: {packet_list}")
+                        raise exceptions.CloudConnectionError(f"Sending packet list failed four times in a row: {packet_list}")
 
     def _handshake(self):
         packet = {"method": "handshake", "user": self.username, "project_id": self.project_id}

--- a/scratchattach/cloud/_base.py
+++ b/scratchattach/cloud/_base.py
@@ -1,60 +1,58 @@
-from abc import ABC, abstractmethod
+import json
+import ssl
+import time
+from abc import ABC
 
 import websocket
-import json
-import time
-from ..utils import exceptions
-import warnings
+
 from ..eventhandlers import cloud_recorder
-import ssl
+from ..utils import exceptions
+
 
 class BaseCloud(ABC):
-
     """
     Base class for a project's cloud variables. Represents a cloud.
 
-    When inheriting from this class, the __init__ function of the inherited class ...
-
+    When inheriting from this class, the __init__ function of the inherited class:
     - must first call the constructor of the super class: super().__init__()
-
     - must then set some attributes
 
     Attributes that must be specified in the __init__ function a class inheriting from this one:
+        project_id: Project id of the cloud variables
 
-    :self.project_id: Project id of the cloud variables
-
-    :self.cloud_host: URL of the websocket server ("wss://..." or "ws://...")
+        cloud_host: URL of the websocket server ("wss://..." or "ws://...")
 
     Attributes that can, but don't have to be specified in the __init__ function:
 
-    :self._session: Either None or a site.session.Session object. Defaults to None.
+        _session: Either None or a site.session.Session object. Defaults to None.
 
-    :self.ws_shortterm_ratelimit: The wait time between cloud variable sets. Defaults to 0.1
+        ws_shortterm_ratelimit: The wait time between cloud variable sets. Defaults to 0.1
 
-    :self.ws_longterm_ratelimit: The amount of cloud variable set that can be performed long-term without ever getting ratelimited
+        ws_longterm_ratelimit: The amount of cloud variable set that can be performed long-term without ever getting ratelimited
 
-    :self.allow_non_numeric: Whether non-numeric cloud variable values are allowed. Defaults to False
+        allow_non_numeric: Whether non-numeric cloud variable values are allowed. Defaults to False
 
-    :self.length_limit: Length limit for cloud variable values. Defaults to 100000
+        length_limit: Length limit for cloud variable values. Defaults to 100000
 
-    :self.username: The username to send during handshake. Defaults to "scratchattach"
+        username: The username to send during handshake. Defaults to "scratchattach"
 
-    :self.header: The header to send. Defaults to None
+        header: The header to send. Defaults to None
 
-    :self.cookie: The cookie to send. Defaults to None
+        cookie: The cookie to send. Defaults to None
 
-    :self.origin: The origin to send. Defaults to None
+        origin: The origin to send. Defaults to None
 
-    :self.print_connect_messages: Whether to print a message on every connect to the cloud server. Defaults to False.
+        print_connect_messages: Whether to print a message on every connect to the cloud server. Defaults to False.
     """
 
-    def __init__(self):
-
-        # Required internal attributes that every object representing a cloud needs to have (no matter what cloud is represented):
+    def __init__(self, **kwargs):
+        # Required internal attributes that every object representing a cloud needs to have
+        # (no matter what cloud is represented):
         self._session = None
-        self.active_connection = False #whether a connection to a cloud variable server is currently established
+        self.active_connection = False  # whether a connection to a cloud variable server is currently established
         self.websocket = websocket.WebSocket(sslopt={"cert_reqs": ssl.CERT_NONE})
-        self.recorder = None # A CloudRecorder object that records cloud activity for the values to be retrieved later will be saved in this attribute as soon as .get_var is called
+        self.recorder = None  # A CloudRecorder object that records cloud activity for the values to be retrieved later,
+        # which will be saved in this attribute as soon as .get_var is called
         self.first_var_set = 0
         self.last_var_set = 0
         self.var_stets_since_first = 0
@@ -63,7 +61,8 @@ class BaseCloud(ABC):
         # (These attributes can be specifically in the constructors of classes inheriting from this base class)
         self.ws_shortterm_ratelimit = 0.06667
         self.ws_longterm_ratelimit = 0.1
-        self.ws_timeout = 3 # Timeout for send operations (after the timeout, the connection will be renewed and the operation will be retried 3 times)
+        self.ws_timeout = 3  # Timeout for send operations (after the timeout,
+        # the connection will be renewed and the operation will be retried 3 times)
         self.allow_non_numeric = False
         self.length_limit = 100000
         self.username = "scratchattach"
@@ -126,7 +125,8 @@ class BaseCloud(ABC):
                         self.websocket.send(packet_string)
                     except Exception:
                         self.active_connection = False
-                        raise exceptions.CloudConnectionError(f"Sending packet list failed four times in a row: {packet_list}")
+                        raise exceptions.CloudConnectionError(
+                            f"Sending packet list failed four times in a row: {packet_list}")
 
     def _handshake(self):
         packet = {"method": "handshake", "user": self.username, "project_id": self.project_id}
@@ -139,8 +139,8 @@ class BaseCloud(ABC):
             cookie=self.cookie,
             origin=self.origin,
             enable_multithread=True,
-            timeout = self.ws_timeout,
-            header = self.header
+            timeout=self.ws_timeout,
+            header=self.header
         )
         self._handshake()
         self.active_connection = True
@@ -166,29 +166,29 @@ class BaseCloud(ABC):
         if not (value in [True, False, float('inf'), -float('inf')]):
             value = str(value)
             if len(value) > self.length_limit:
-                raise(exceptions.InvalidCloudValue(
+                raise (exceptions.InvalidCloudValue(
                     f"Value exceeds length limit: {str(value)}"
                 ))
             if not self.allow_non_numeric:
                 x = value.replace(".", "")
                 x = x.replace("-", "")
                 if not (x.isnumeric() or x == ""):
-                    raise(exceptions.InvalidCloudValue(
+                    raise (exceptions.InvalidCloudValue(
                         "Value not numeric"
                     ))
 
     def _enforce_ratelimit(self, *, n):
         # n is the amount of variables being set
-        if (time.time() - self.first_var_set) / (self.var_stets_since_first+1) > self.ws_longterm_ratelimit: # if the average delay between cloud variable sets has been bigger than the long-term rate-limit, cloud variables can be set fast (wait time smaller than long-term rate limit) again
+        if (time.time() - self.first_var_set) / (
+                self.var_stets_since_first + 1) > self.ws_longterm_ratelimit:  # if the average delay between cloud variable sets has been bigger than the long-term rate-limit, cloud variables can be set fast (wait time smaller than long-term rate limit) again
             self.var_stets_since_first = 0
             self.first_var_set = time.time()
 
         wait_time = self.ws_shortterm_ratelimit * n
-        if time.time() - self.first_var_set > 25: # if cloud variables have been continously set fast (wait time smaller than long-term rate limit) for 25 seconds, they should be set slow now (wait time = long-term rate limit) to avoid getting rate-limited
+        if time.time() - self.first_var_set > 25:  # if cloud variables have been continously set fast (wait time smaller than long-term rate limit) for 25 seconds, they should be set slow now (wait time = long-term rate limit) to avoid getting rate-limited
             wait_time = self.ws_longterm_ratelimit * n
         while self.last_var_set + wait_time >= time.time():
             time.sleep(0.001)
-        
 
     def set_var(self, variable, value):
         """
@@ -231,7 +231,7 @@ class BaseCloud(ABC):
             self.connect()
         if intelligent_waits:
             self._enforce_ratelimit(n=len(list(var_value_dict.keys())))
-            
+
         self.var_stets_since_first += len(list(var_value_dict.keys()))
 
         packet_list = []
@@ -256,7 +256,7 @@ class BaseCloud(ABC):
             self.recorder = cloud_recorder.CloudRecorder(self, initial_values=recorder_initial_values)
             self.recorder.start()
             start_time = time.time()
-            while not (self.recorder.cloud_values != {} or start_time < time.time() -5):
+            while not (self.recorder.cloud_values != {} or start_time < time.time() - 5):
                 time.sleep(0.01)
         return self.recorder.get_var(var)
 
@@ -265,7 +265,7 @@ class BaseCloud(ABC):
             self.recorder = cloud_recorder.CloudRecorder(self, initial_values=recorder_initial_values)
             self.recorder.start()
             start_time = time.time()
-            while not (self.recorder.cloud_values != {} or start_time < time.time() -5):
+            while not (self.recorder.cloud_values != {} or start_time < time.time() - 5):
                 time.sleep(0.01)
         return self.recorder.get_all_vars()
 
@@ -273,9 +273,11 @@ class BaseCloud(ABC):
         from ..eventhandlers.cloud_events import CloudEvents
         return CloudEvents(self)
 
-    def requests(self, *, no_packet_loss=False, used_cloud_vars=["1", "2", "3", "4", "5", "6", "7", "8", "9"], respond_order="receive"):
+    def requests(self, *, no_packet_loss=False, used_cloud_vars=["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+                 respond_order="receive"):
         from ..eventhandlers.cloud_requests import CloudRequests
-        return CloudRequests(self, used_cloud_vars=used_cloud_vars, no_packet_loss=no_packet_loss, respond_order=respond_order)
+        return CloudRequests(self, used_cloud_vars=used_cloud_vars, no_packet_loss=no_packet_loss,
+                             respond_order=respond_order)
 
     def storage(self, *, no_packet_loss=False, used_cloud_vars=["1", "2", "3", "4", "5", "6", "7", "8", "9"]):
         from ..eventhandlers.cloud_storage import CloudStorage

--- a/scratchattach/cloud/cloud.py
+++ b/scratchattach/cloud/cloud.py
@@ -91,9 +91,10 @@ class ScratchCloud(BaseCloud):
         else:
             return super().events()
 
-class TwCloud(BaseCloud):
 
-    def __init__(self, *, project_id, cloud_host="wss://clouddata.turbowarp.org", purpose="", contact=""):
+class TwCloud(BaseCloud):
+    def __init__(self, *, project_id, cloud_host="wss://clouddata.turbowarp.org", purpose="", contact="",
+                 _session=None):
         super().__init__()
         
         self.project_id = project_id

--- a/scratchattach/eventhandlers/cloud_requests.py
+++ b/scratchattach/eventhandlers/cloud_requests.py
@@ -167,8 +167,8 @@ class CloudRequests(CloudEvents):
     def _set_FROM_HOST_var(self, value):
         try:
             self.cloud.set_var(f"FROM_HOST_{self.used_cloud_vars[self.current_var]}", value)
-        except exceptions.ConnectionError:
-            self.call_even("on_disconnect")
+        except exceptions.CloudConnectionError:
+            self.call_event("on_disconnect")
         except Exception as e:
             print("scratchattach: internal error while responding (please submit a bug report on GitHub):", e)
         self.current_var += 1

--- a/scratchattach/other/project_json_capabilities.py
+++ b/scratchattach/other/project_json_capabilities.py
@@ -1,34 +1,38 @@
 """Project JSON reading and editing capabilities.
 This code is still in BETA, there are still bugs and potential consistency issues to be fixed. New features will be added."""
 
-import random
-import zipfile
-import string
-from abc import ABC, abstractmethod
-from ..utils import exceptions
-from ..utils.requests import Requests as requests
-from ..utils.commons import empty_project_json
-import json
-import hashlib
+# Note: You may want to make this into multiple files for better organisation
 
-def load_components(json_data:list, ComponentClass, target_list):
+import hashlib
+import json
+import random
+import string
+import zipfile
+from abc import ABC, abstractmethod
+
+from ..utils import exceptions
+from ..utils.commons import empty_project_json
+from ..utils.requests import Requests as requests
+
+
+# noinspection PyPep8Naming
+def load_components(json_data: list, ComponentClass: type, target_list: list):
     for element in json_data:
         component = ComponentClass()
         component.from_json(element)
         target_list.append(component)
 
+
 class ProjectBody:
-
     class BaseProjectBodyComponent(ABC):
-
         def __init__(self, **entries):
             # Attributes every object needs to have:
             self.id = None
             # Update attributes from entries dict:
             self.__dict__.update(entries)
-        
+
         @abstractmethod
-        def from_json(self, data:dict):
+        def from_json(self, data: dict):
             pass
 
         @abstractmethod
@@ -44,25 +48,26 @@ class ProjectBody:
             """
             self.id = ''.join(random.choices(string.ascii_letters + string.digits, k=20))
 
-
     class Block(BaseProjectBodyComponent):
-        
+
         # Thanks to @MonkeyBean2 for some scripts
 
         def from_json(self, data: dict):
-            self.opcode = data["opcode"] # The name of the block
-            self.next_id = data.get("next", None) # The id of the block attached below this block
-            self.parent_id = data.get("parent", None) # The id of the block that this block is attached to
-            self.input_data = data.get("inputs", None) # The blocks inside of the block (if the block is a loop or an if clause for example)
-            self.fields = data.get("fields", None) # The values inside the block's inputs
-            self.shadow = data.get("shadow", False) # Whether the block is displayed with a shadow
-            self.topLevel = data.get("topLevel", False) # Whether the block has no parent
-            self.mutation = data.get("mutation", None) # For custom blocks
-            self.x = data.get("x", None) # x position if topLevel
-            self.y = data.get("y", None) # y position if topLevel
-            
+            self.opcode = data["opcode"]  # The name of the block
+            self.next_id = data.get("next", None)  # The id of the block attached below this block
+            self.parent_id = data.get("parent", None)  # The id of the block that this block is attached to
+            self.input_data = data.get("inputs", None)  # The blocks inside of the block (if the block is a loop or an if clause for example)
+            self.fields = data.get("fields", None)  # The values inside the block's inputs
+            self.shadow = data.get("shadow", False)  # Whether the block is displayed with a shadow
+            self.topLevel = data.get("topLevel", False)  # Whether the block has no parent
+            self.mutation = data.get("mutation", None)  # For custom blocks
+            self.x = data.get("x", None)  # x position if topLevel
+            self.y = data.get("y", None)  # y position if topLevel
+
         def to_json(self):
-            output = {"opcode":self.opcode,"next":self.next_id,"parent":self.parent_id,"inputs":self.input_data,"fields":self.fields,"shadow":self.shadow,"topLevel":self.topLevel,"mutation":self.mutation,"x":self.x,"y":self.y}
+            output = {"opcode": self.opcode, "next": self.next_id, "parent": self.parent_id, "inputs": self.input_data,
+                      "fields": self.fields, "shadow": self.shadow, "topLevel": self.topLevel,
+                      "mutation": self.mutation, "x": self.x, "y": self.y}
             return {k: v for k, v in output.items() if v}
 
         def attached_block(self):
@@ -81,7 +86,7 @@ class ProjectBody:
             block = self
             while block.parent_id is not None:
                 block = block.previous_block()
-                chain.insert(0,block)
+                chain.insert(0, block)
             return chain
 
         def attached_chain(self):
@@ -94,7 +99,7 @@ class ProjectBody:
 
         def complete_chain(self):
             return self.previous_chain() + [self] + self.attached_chain()
-                
+
         def duplicate_single_block(self):
             new_block = ProjectBody.Block(**self.__dict__)
             new_block.parent_id = None
@@ -102,7 +107,7 @@ class ProjectBody:
             new_block._generate_new_id()
             self.sprite.blocks.append(new_block)
             return new_block
-        
+
         def duplicate_chain(self):
             blocks_to_dupe = [self] + self.attached_chain()
             duped = []
@@ -112,8 +117,8 @@ class ProjectBody:
                 new_block.next_id = None
                 new_block._generate_new_id()
                 if i != 0:
-                    new_block.parent_id = duped[i-1].id
-                    duped[i-1].next_id = new_block.id
+                    new_block.parent_id = duped[i - 1].id
+                    duped[i - 1].next_id = new_block.id
                 duped.append(new_block)
             self.sprite.blocks += duped
             return duped
@@ -126,7 +131,7 @@ class ProjectBody:
                 self.sprite.blocks.append(old_parent_block)
 
             self.parent_id = new_parent_id
-            
+
             if self.parent_id is not None:
                 new_parent_block = self.sprite.block_by_id(self.parent_id)
                 self.sprite.blocks.remove(new_parent_block)
@@ -159,7 +164,7 @@ class ProjectBody:
             self.sprite.blocks.remove(self)
 
             self.reattach_chain(None)
-            
+
             to_delete = self.attached_chain()
             for block in to_delete:
                 self.sprite.blocks.remove(block)
@@ -171,36 +176,36 @@ class ProjectBody:
             for input in self.input_data:
                 inputs.append(self.sprite.block_by_id(self.input_data[input][1]))
 
-
     class Sprite(BaseProjectBodyComponent):
 
-        def from_json(self, data:dict):
+        def from_json(self, data: dict):
             self.isStage = data["isStage"]
             self.name = data["name"]
-            self.id = self.name # Sprites are uniquely identifiable through their name
+            self.id = self.name  # Sprites are uniquely identifiable through their name
             self.variables = []
-            for variable_id in data["variables"]: #self.lists is a dict with the list_id as key and info as value
+            for variable_id in data["variables"]:  # self.lists is a dict with the list_id as key and info as value
                 pvar = ProjectBody.Variable(id=variable_id)
                 pvar.from_json(data["variables"][variable_id])
                 self.variables.append(pvar)
             self.lists = []
-            for list_id in data["lists"]: #self.lists is a dict with the list_id as key and info as value
+            for list_id in data["lists"]:  # self.lists is a dict with the list_id as key and info as value
                 plist = ProjectBody.List(id=list_id)
                 plist.from_json(data["lists"][list_id])
                 self.lists.append(plist)
             self.broadcasts = data["broadcasts"]
             self.blocks = []
-            for block_id in data["blocks"]: #self.blocks is a dict with the block_id as key and block content as value
-                if isinstance(data["blocks"][block_id], dict): # Sometimes there is a weird list at the end of the blocks list. This list is ignored
+            for block_id in data["blocks"]:  # self.blocks is a dict with the block_id as key and block content as value
+                if isinstance(data["blocks"][block_id],
+                              dict):  # Sometimes there is a weird list at the end of the blocks list. This list is ignored
                     block = ProjectBody.Block(id=block_id, sprite=self)
                     block.from_json(data["blocks"][block_id])
                     self.blocks.append(block)
             self.comments = data["comments"]
             self.currentCostume = data["currentCostume"]
             self.costumes = []
-            load_components(data["costumes"], ProjectBody.Asset, self.costumes) # load lists
+            load_components(data["costumes"], ProjectBody.Asset, self.costumes)  # load lists
             self.sounds = []
-            load_components(data["sounds"], ProjectBody.Asset, self.sounds) # load lists
+            load_components(data["sounds"], ProjectBody.Asset, self.sounds)  # load lists
             self.volume = data["volume"]
             self.layerOrder = data["layerOrder"]
             if self.isStage:
@@ -236,61 +241,71 @@ class ProjectBody:
             return return_data
 
         def variable_by_id(self, variable_id):
-            matching = list(filter(lambda x : x.id == variable_id, self.variables))
+            matching = list(filter(lambda x: x.id == variable_id, self.variables))
             if matching == []:
                 return None
             return matching[0]
 
         def list_by_id(self, list_id):
-            matching = list(filter(lambda x : x.id == list_id, self.lists))
+            matching = list(filter(lambda x: x.id == list_id, self.lists))
             if matching == []:
                 return None
             return matching[0]
 
         def variable_by_name(self, variable_name):
-            matching = list(filter(lambda x : x.name == variable_name, self.variables))
+            matching = list(filter(lambda x: x.name == variable_name, self.variables))
             if matching == []:
                 return None
             return matching[0]
 
         def list_by_name(self, list_name):
-            matching = list(filter(lambda x : x.name == list_name, self.lists))
+            matching = list(filter(lambda x: x.name == list_name, self.lists))
             if matching == []:
                 return None
             return matching[0]
 
         def block_by_id(self, block_id):
-            matching = list(filter(lambda x : x.id == block_id, self.blocks))
+            matching = list(filter(lambda x: x.id == block_id, self.blocks))
             if matching == []:
                 return None
             return matching[0]
-        
+
         # -- Functions to modify project contents --
 
         def create_sound(self, asset_content, *, name="new sound", dataFormat="mp3", rate=4800, sampleCount=4800):
             data = asset_content if isinstance(asset_content, bytes) else open(asset_content, "rb").read()
 
             new_asset_id = hashlib.md5(data).hexdigest()
-            new_asset = ProjectBody.Asset(assetId=new_asset_id, name=name, id=new_asset_id, dataFormat=dataFormat, rate=rate, sampleCound=sampleCount, md5ext=new_asset_id+"."+dataFormat, filename=new_asset_id+"."+dataFormat)
+            new_asset = ProjectBody.Asset(assetId=new_asset_id, name=name, id=new_asset_id, dataFormat=dataFormat,
+                                          rate=rate, sampleCound=sampleCount, md5ext=new_asset_id + "." + dataFormat,
+                                          filename=new_asset_id + "." + dataFormat)
             self.sounds.append(new_asset)
             if not hasattr(self, "projectBody"):
-                print("Warning: Since there's no project body connected to this object, the new sound asset won't be uploaded to Scratch")
+                print(
+                    "Warning: Since there's no project body connected to this object, the new sound asset won't be uploaded to Scratch")
             elif self.projectBody._session is None:
-                print("Warning: Since there's no login connected to this object, the new sound asset won't be uploaded to Scratch")
+                print(
+                    "Warning: Since there's no login connected to this object, the new sound asset won't be uploaded to Scratch")
             else:
                 self._session.upload_asset(data, asset_id=new_asset_id, file_ext=dataFormat)
             return new_asset
 
-        def create_costume(self, asset_content, *, name="new costume", dataFormat="svg", rotationCenterX=0, rotationCenterY=0):
+        def create_costume(self, asset_content, *, name="new costume", dataFormat="svg", rotationCenterX=0,
+                           rotationCenterY=0):
             data = asset_content if isinstance(asset_content, bytes) else open(asset_content, "rb").read()
 
             new_asset_id = hashlib.md5(data).hexdigest()
-            new_asset = ProjectBody.Asset(assetId=new_asset_id, name=name, id=new_asset_id, dataFormat=dataFormat, rotationCenterX=rotationCenterX, rotationCenterY=rotationCenterY, md5ext=new_asset_id+"."+dataFormat, filename=new_asset_id+"."+dataFormat)
+            new_asset = ProjectBody.Asset(assetId=new_asset_id, name=name, id=new_asset_id, dataFormat=dataFormat,
+                                          rotationCenterX=rotationCenterX, rotationCenterY=rotationCenterY,
+                                          md5ext=new_asset_id + "." + dataFormat,
+                                          filename=new_asset_id + "." + dataFormat)
             self.costumes.append(new_asset)
             if not hasattr(self, "projectBody"):
-                print("Warning: Since there's no project body connected to this object, the new costume asset won't be uploaded to Scratch")
+                print(
+                    "Warning: Since there's no project body connected to this object, the new costume asset won't be uploaded to Scratch")
             elif self.projectBody._session is None:
-                print("Warning: Since there's no login connected to this object, the new costume asset won't be uploaded to Scratch")
+                print(
+                    "Warning: Since there's no login connected to this object, the new costume asset won't be uploaded to Scratch")
             else:
                 self._session.upload_asset(data, asset_id=new_asset_id, file_ext=dataFormat)
             return new_asset
@@ -304,7 +319,7 @@ class ProjectBody:
             new_list = ProjectBody.List(name=name, value=value)
             self.lists.append(new_list)
             return new_list
-        
+
         def add_block(self, block, *, parent_id=None):
             block.parent_id = None
             block.next_id = None
@@ -317,15 +332,15 @@ class ProjectBody:
             for block in block_chain:
                 self.add_block(block, parent_id=parent)
                 parent = str(block.id)
-        
+
     class Variable(BaseProjectBodyComponent):
-        
+
         def __init__(self, **entries):
             super().__init__(**entries)
             if self.id is None:
                 self._generate_new_id()
 
-        def from_json(self, data:list):
+        def from_json(self, data: list):
             self.name = data[0]
             self.saved_value = data[1]
             self.is_cloud = len(data) == 3
@@ -335,7 +350,7 @@ class ProjectBody:
                 return [self.name, self.saved_value, True]
             else:
                 return [self.name, self.saved_value]
-        
+
         def make_cloud_variable(self):
             self.is_cloud = True
 
@@ -346,16 +361,16 @@ class ProjectBody:
             if self.id is None:
                 self._generate_new_id()
 
-        def from_json(self, data:list):
+        def from_json(self, data: list):
             self.name = data[0]
             self.saved_content = data[1]
-        
+
         def to_json(self):
             return [self.name, self.saved_content]
-        
+
     class Monitor(BaseProjectBodyComponent):
 
-        def from_json(self, data:dict):
+        def from_json(self, data: dict):
             self.__dict__.update(data)
 
         def to_json(self):
@@ -375,12 +390,12 @@ class ProjectBody:
 
     class Asset(BaseProjectBodyComponent):
 
-        def from_json(self, data:dict):
+        def from_json(self, data: dict):
             self.__dict__.update(data)
             self.id = self.assetId
             self.filename = self.md5ext
             self.download_url = f"https://assets.scratch.mit.edu/internalapi/asset/{self.filename}"
-        
+
         def to_json(self):
             return_data = dict(self.__dict__)
             return_data.pop("filename")
@@ -390,7 +405,7 @@ class ProjectBody:
 
         def download(self, *, filename=None, dir=""):
             if not (dir.endswith("/") or dir.endswith("\\")):
-                dir = dir+"/"
+                dir = dir + "/"
             try:
                 if filename is None:
                     filename = str(self.filename)
@@ -406,7 +421,7 @@ class ProjectBody:
                     )
                 )
 
-    def __init__(self, *, sprites=[], monitors=[], extensions=[], meta=[{"agent":None}], _session=None):
+    def __init__(self, *, sprites=[], monitors=[], extensions=[], meta=[{"agent": None}], _session=None):
         # sprites are called "targets" in the initial API response
         self.sprites = sprites
         self.monitors = monitors
@@ -414,7 +429,7 @@ class ProjectBody:
         self.meta = meta
         self._session = _session
 
-    def from_json(self, data:dict):
+    def from_json(self, data: dict):
         """
         Imports the project data from a dict that contains the raw project json
         """
@@ -423,8 +438,8 @@ class ProjectBody:
         load_components(data["targets"], ProjectBody.Sprite, self.sprites)
         # Save origin of sprite in Sprite object:
         for sprite in self.sprites:
-            sprite.projectBody = self            
-        # Load monitors:
+            sprite.projectBody = self
+            # Load monitors:
         self.monitors = []
         load_components(data["monitors"], ProjectBody.Monitor, self.monitors)
         # Save origin of monitor in Monitor object:
@@ -449,16 +464,17 @@ class ProjectBody:
 
     def blocks(self):
         return [block for sprite in self.sprites for block in sprite.blocks]
-    
+
     def block_count(self):
         return len(self.blocks())
-    
+
     def assets(self):
-        return [sound for sprite in self.sprites for sound in sprite.sounds] + [costume for sprite in self.sprites for costume in sprite.costumes]
+        return [sound for sprite in self.sprites for sound in sprite.sounds] + [costume for sprite in self.sprites for
+                                                                                costume in sprite.costumes]
 
     def asset_count(self):
         return len(self.assets())
-    
+
     def variable_by_id(self, variable_id):
         for sprite in self.sprites:
             r = sprite.variable_by_id(variable_id)
@@ -470,16 +486,16 @@ class ProjectBody:
             r = sprite.list_by_id(list_id)
             if r is not None:
                 return r
-    
+
     def sprite_by_name(self, sprite_name):
-        matching = list(filter(lambda x : x.name == sprite_name, self.sprites))
+        matching = list(filter(lambda x: x.name == sprite_name, self.sprites))
         if matching == []:
             return None
         return matching[0]
-    
+
     def user_agent(self):
         return self.meta["agent"]
-    
+
     def save(self, *, filename=None, dir=""):
         """
         Saves the project body to the given directory.
@@ -496,15 +512,18 @@ class ProjectBody:
         with open(f"{dir}{filename}.sb3", "w") as d:
             json.dump(self.to_json(), d, indent=4)
 
+
 def get_empty_project_pb():
     pb = ProjectBody()
     pb.from_json(empty_project_json)
     return pb
 
-def get_pb_from_dict(project_json:dict):
+
+def get_pb_from_dict(project_json: dict):
     pb = ProjectBody()
     pb.from_json(project_json)
     return pb
+
 
 def _load_sb3_file(path_to_file):
     try:
@@ -520,19 +539,21 @@ def _load_sb3_file(path_to_file):
             else:
                 raise ValueError("specified sb3 archive doesn't contain project.json")
 
+
 def read_sb3_file(path_to_file):
     pb = ProjectBody()
     pb.from_json(_load_sb3_file(path_to_file))
     return pb
 
+
 def download_asset(asset_id_with_file_ext, *, filename=None, dir=""):
     if not (dir.endswith("/") or dir.endswith("\\")):
-        dir = dir+"/"
+        dir = dir + "/"
     try:
         if filename is None:
             filename = str(asset_id_with_file_ext)
         response = requests.get(
-            "https://assets.scratch.mit.edu/"+str(asset_id_with_file_ext),
+            "https://assets.scratch.mit.edu/" + str(asset_id_with_file_ext),
             timeout=10,
         )
         open(f"{dir}{filename}", "wb").write(response.content)

--- a/scratchattach/site/_base.py
+++ b/scratchattach/site/_base.py
@@ -1,9 +1,17 @@
 from abc import ABC, abstractmethod
+
 import requests
-from threading import Thread
+# from threading import Thread
 from ..utils import exceptions, commons
 
+
 class BaseSiteComponent(ABC):
+    @abstractmethod
+    def __init__(self):
+        self._session = None
+        self._cookies = None
+        self._headers = None
+        self.update_API = None
 
     def update(self):
         """
@@ -11,8 +19,8 @@ class BaseSiteComponent(ABC):
         """
         response = self.update_function(
             self.update_API,
-            headers = self._headers,
-            cookies = self._cookies, timeout=10
+            headers=self._headers,
+            cookies=self._cookies, timeout=10
         )
         # Check for 429 error:
         if "429" in str(response):
@@ -44,3 +52,7 @@ class BaseSiteComponent(ABC):
         """
         return commons._get_object(identificator_id, identificator, Class, NotFoundException, self._session)
 
+    update_function = requests.get
+    """
+    Internal function run on update. Function is a method of the 'requests' module/class
+    """

--- a/scratchattach/site/forum.py
+++ b/scratchattach/site/forum.py
@@ -32,8 +32,8 @@ class ForumTopic(BaseSiteComponent):
 
     :.update(): Updates the attributes
     '''
-    def __init__(self, **entries):
 
+    def __init__(self, **entries):
         # Info on how the .update method has to fetch the data:
         self.update_function = requests.get
         self.update_API = f"https://scratch.mit.edu/discuss/feeds/topic/{entries['id']}/"

--- a/scratchattach/site/session.py
+++ b/scratchattach/site/session.py
@@ -201,7 +201,7 @@ class Session(BaseSiteComponent):
 
         data = commons.api_iterative(
             f"https://api.scratch.mit.edu/users/{self._username}/messages",
-            limit=limit, offset=offset, headers=self._headers, cookies=self._cookies, add_params=add_params
+            limit=limit, offset=offset, _headers=self._headers, cookies=self._cookies, add_params=add_params
         )
         return commons.parse_object_list(data, activity.Activity, self)
 
@@ -211,7 +211,7 @@ class Session(BaseSiteComponent):
         """
         return commons.api_iterative(
             f"https://api.scratch.mit.edu/users/{self._username}/messages/admin",
-            limit=limit, offset=offset, headers=self._headers, cookies=self._cookies
+            limit=limit, offset=offset, _headers=self._headers, cookies=self._cookies
         )
 
     def clear_messages(self):
@@ -253,7 +253,7 @@ class Session(BaseSiteComponent):
             add_params = f"&dateLimit={date_limit}"
         data = commons.api_iterative(
             f"https://api.scratch.mit.edu/users/{self._username}/following/users/activity",
-            limit=limit, offset=offset, headers=self._headers, cookies=self._cookies, add_params=add_params
+            limit=limit, offset=offset, _headers=self._headers, cookies=self._cookies, add_params=add_params
         )
         return commons.parse_object_list(data, activity.Activity, self)
 
@@ -271,7 +271,7 @@ class Session(BaseSiteComponent):
         """
         data = commons.api_iterative(
             f"https://api.scratch.mit.edu/users/{self._username}/following/users/loves",
-            limit=limit, offset=offset, headers=self._headers, cookies=self._cookies
+            limit=limit, offset=offset, _headers=self._headers, cookies=self._cookies
         )
         return commons.parse_object_list(data, project.Project, self)
 
@@ -414,7 +414,8 @@ class Session(BaseSiteComponent):
             add_params=f"&language={language}&mode={mode}&q={query}")
         return commons.parse_object_list(response, project.Project, self)
 
-    def search_studios(self, *, query="", mode="trending", language="en", limit=40, offset=0):
+    def search_studios(self, *, query: str = "", mode: str = "trending", language: str = "en", limit: int = 40,
+                       offset: int = 0) -> list['studio.Studio']:
         if not query:
             raise ValueError("The query can't be empty for search")
         response = commons.api_iterative(
@@ -422,7 +423,8 @@ class Session(BaseSiteComponent):
             add_params=f"&language={language}&mode={mode}&q={query}")
         return commons.parse_object_list(response, studio.Studio, self)
 
-    def explore_studios(self, *, query="", mode="trending", language="en", limit=40, offset=0):
+    def explore_studios(self, *, query: str = "", mode: str = "trending", language: str = "en", limit: int = 40,
+                        offset: int = 0) -> list['studio.Studio']:
         if not query:
             raise ValueError("The query can't be empty for explore")
         response = commons.api_iterative(
@@ -432,7 +434,8 @@ class Session(BaseSiteComponent):
 
     # --- Create project API ---
 
-    def create_project(self, *, title=None, project_json=empty_project_json, parent_id=None):  # not working
+    def create_project(self, *, title: str = None, project_json: dict = empty_project_json,
+                       parent_id=None) -> 'project.Project':  # not working
         """
         Creates a project on the Scratch website.
 
@@ -448,7 +451,10 @@ class Session(BaseSiteComponent):
                 CREATE_PROJECT_USES.pop()
             else:
                 raise exceptions.BadRequest(
-                    "Rate limit for creating Scratch projects exceeded.\nThis rate limit is enforced by scratchattach, not by the Scratch API.\nFor security reasons, it cannot be turned off.\n\nDon't spam-create projects, it WILL get you banned.")
+                    "Rate limit for creating Scratch projects exceeded.\n"
+                    "This rate limit is enforced by scratchattach, not by the Scratch API.\n"
+                    "For security reasons, it cannot be turned off.\n\n"
+                    "Don't spam-create projects, it WILL get you banned.")
             CREATE_PROJECT_USES.insert(0, time.time())
 
         if title is None:
@@ -480,7 +486,10 @@ class Session(BaseSiteComponent):
                 CREATE_STUDIO_USES.pop()
             else:
                 raise exceptions.BadRequest(
-                    "Rate limit for creating Scratch studios exceeded.\nThis rate limit is enforced by scratchattach, not by the Scratch API.\nFor security reasons, it cannot be turned off.\n\nDon't spam-create studios, it WILL get you banned.")
+                    "Rate limit for creating Scratch studios exceeded.\n"
+                    "This rate limit is enforced by scratchattach, not by the Scratch API.\n"
+                    "For security reasons, it cannot be turned off.\n\n"
+                    "Don't spam-create studios, it WILL get you banned.")
             CREATE_STUDIO_USES.insert(0, time.time())
 
         if self.new_scratcher:
@@ -501,8 +510,9 @@ class Session(BaseSiteComponent):
 
     # --- My stuff page ---
 
-    def mystuff_projects(self, filter_arg="all", *, page=1, sort_by="", descending=True):
-        '''
+    def mystuff_projects(self, filter_arg: str = "all", *, page: int = 1, sort_by: str = '', descending: bool = True) \
+            -> list['project.Project']:
+        """
         Gets the projects from the "My stuff" page.
 
         Args:
@@ -515,7 +525,7 @@ class Session(BaseSiteComponent):
 
         Returns:
             list<scratchattach.project.Project>: A list with the projects from the "My Stuff" page, each project is represented by a Project object.
-        '''
+        """
         if descending:
             ascsort = ""
             descsort = sort_by
@@ -547,9 +557,10 @@ class Session(BaseSiteComponent):
                 ))
             return projects
         except Exception:
-            raise (exceptions.FetchError)
+            raise exceptions.FetchError()
 
-    def mystuff_studios(self, filter_arg="all", *, page=1, sort_by="", descending=True):
+    def mystuff_studios(self, filter_arg: str = "all", *, page: int = 1, sort_by: str = "", descending: bool = True) \
+            -> list['studio.Studio']:
         if descending:
             ascsort = ""
             descsort = sort_by
@@ -558,7 +569,8 @@ class Session(BaseSiteComponent):
             descsort = ""
         try:
             targets = requests.get(
-                f"https://scratch.mit.edu/site-api/galleries/{filter_arg}/?page={page}&ascsort={ascsort}&descsort={descsort}",
+                f"https://scratch.mit.edu/site-api/galleries/{filter_arg}/"
+                f"?page={page}&ascsort={ascsort}&descsort={descsort}",
                 headers=headers,
                 cookies=self._cookies,
                 timeout=10,
@@ -581,33 +593,34 @@ class Session(BaseSiteComponent):
                 ))
             return studios
         except Exception:
-            raise (exceptions.FetchError)
+            raise exceptions.FetchError()
 
-    def backpack(self, limit=20, offset=0):
-        '''
+    def backpack(self, limit: int = 20, offset: int = 0) -> list[dict]:
+        """
         Lists the assets that are in the backpack of the user associated with the session.
 
         Returns:
             list<dict>: List that contains the backpack items as dicts
-        '''
+        """
         data = commons.api_iterative(
             f"https://backpack.scratch.mit.edu/{self._username}",
-            limit=limit, offset=offset, headers=self._headers
+            limit=limit, offset=offset, _headers=self._headers
         )
         return commons.parse_object_list(data, backpack_asset.BackpackAsset, self)
 
-    def delete_from_backpack(self, backpack_asset_id):
-        '''
+    def delete_from_backpack(self, backpack_asset_id) -> 'backpack_asset.BackpackAsset':
+        """
         Deletes an asset from the backpack.
 
         Args:
             backpack_asset_id: ID of the backpack asset that will be deleted
-        '''
+        """
         return backpack_asset.BackpackAsset(id=backpack_asset_id, _session=self).delete()
 
-    def become_scratcher_invite(self):
+    def become_scratcher_invite(self) -> dict:
         """
-        If you are a new Scratcher and have been invited for becoming a Scratcher, this API endpoint will provide more info on the invite.
+        If you are a new Scratcher and have been invited for becoming a Scratcher, this API endpoint will provide
+        more info on the invite.
         """
         return requests.get(f"https://api.scratch.mit.edu/users/{self.username}/invites", headers=self._headers,
                             cookies=self._cookies).json()
@@ -615,19 +628,19 @@ class Session(BaseSiteComponent):
     # --- Connect classes inheriting from BaseCloud ---
 
     # noinspection PyPep8Naming
-    def connect_cloud(self, project_id, *, CloudClass: Type[_base.BaseCloud] = cloud.ScratchCloud) -> Type[
-        _base.BaseCloud]:
+    def connect_cloud(self, project_id, *, CloudClass: Type[_base.BaseCloud] = cloud.ScratchCloud) \
+            -> Type[_base.BaseCloud]:
         """
         Connects to a cloud (by default Scratch's cloud) as logged-in user.
 
         Args:
             project_id:
         
-        Keyword arguments:
-            CloudClass: The class that the returned object should be of. By default, this class is scratchattach.cloud.ScratchCloud.
+        Keyword arguments: CloudClass: The class that the returned object should be of. By default, this class is
+        scratchattach.cloud.ScratchCloud.
 
-        Returns:
-            Type[scratchattach._base.BaseCloud]: An object representing the cloud of a project. Can be of any class inheriting from BaseCloud.
+        Returns: Type[scratchattach._base.BaseCloud]: An object representing the cloud of a project. Can be of any
+        class inheriting from BaseCloud.
         """
         return CloudClass(project_id=project_id, _session=self)
 
@@ -652,7 +665,7 @@ class Session(BaseSiteComponent):
     # noinspection PyPep8Naming
     # Class is camelcase here
     def _make_linked_object(self, identificator_name, identificator, Class: BaseSiteComponent,
-                            NotFoundException: Exception):
+                            NotFoundException: Exception) -> BaseSiteComponent:
         """
         The Session class doesn't save the login in a ._session attribute, but IS the login ITSELF.
 
@@ -811,7 +824,7 @@ sess
 
         try:
             category_name = soup.find('h4').find("span").get_text()
-        except Exception as e:
+        except Exception:
             raise exceptions.BadRequest("Invalid category id")
 
         try:
@@ -941,7 +954,7 @@ def login(username, password, *, timeout=10) -> Session:
     return login_by_id(session_id, username=username, password=password)
 
 
-def login_by_session_string(session_string) -> Session:
+def login_by_session_string(session_string: str) -> Session:
     session_string = base64.b64decode(session_string).decode()  # unobfuscate
     session_data = json.loads(session_string)
     try:

--- a/scratchattach/site/session.py
+++ b/scratchattach/site/session.py
@@ -1,32 +1,33 @@
 """Session class and login function"""
 
-import json
-import re
-import warnings
-import pathlib
-import hashlib
-import time
-import random
 import base64
-import secrets
+import hashlib
+import json
+import pathlib
+import random
+import re
+import time
+import warnings
+# import secrets
+# import zipfile
 from typing import Type
-import zipfile
 
-from . import forum
-
-from ..utils import commons
-
-from ..cloud import cloud, _base
-from . import user, project, backpack_asset, classroom
-from ..utils import exceptions
-from . import studio
-from . import classroom
-from ..eventhandlers import message_events, filterbot
-from . import activity
-from ._base import BaseSiteComponent
-from ..utils.commons import headers, empty_project_json, webscrape_count
 from bs4 import BeautifulSoup
+
+from . import activity
+from . import classroom
+from . import forum
+from . import studio
+from . import user, project, backpack_asset
+from ._base import BaseSiteComponent
+# noinspection PyProtectedMember
+# Pycharm doesn't like that you are importing a protected member '_base'
+from ..cloud import cloud, _base
+from ..eventhandlers import message_events, filterbot
 from ..other import project_json_capabilities
+from ..utils import commons
+from ..utils import exceptions
+from ..utils.commons import headers, empty_project_json, webscrape_count
 from ..utils.requests import Requests as requests
 
 CREATE_PROJECT_USES = []
@@ -34,31 +35,23 @@ CREATE_STUDIO_USES = []
 
 
 class Session(BaseSiteComponent):
-    '''
+    """
     Represents a Scratch log in / session. Stores authentication data (session id and xtoken).
 
     Attributes:
-
-    :.id: The session id associated with the login
-
-    :.username: The username associated with the login
-
-    :.xtoken: The xtoken associated with the login
-
-    :.email: The email address associated with the logged in account
-
-    :.new_scratcher: Returns True if the associated account is a new Scratcher
-
-    :.mute_status: Information about commenting restrictions of the associated account
-
-    :.banned: Returns True if the associated account is banned
-    '''
+        id: The session id associated with the login
+        username: The username associated with the login
+        xtoken: The xtoken associated with the login
+        email: The email address associated with the logged in account
+        new_scratcher: True if the associated account is a new Scratcher
+        mute_status: Information about commenting restrictions of the associated account
+        banned: Returns True if the associated account is banned
+    """
 
     def __str__(self):
         return "Login for account: {self.username}"
 
     def __init__(self, **entries):
-
         # Info on how the .update method has to fetch the data:
         self.update_function = requests.post
         self.update_API = "https://scratch.mit.edu/session"
@@ -69,23 +62,26 @@ class Session(BaseSiteComponent):
         self.xtoken = None
         self.new_scratcher = None
 
+        # Set attributes that Session object may get
+        self._user = None
+
         # Update attributes from entries dict:
         self.__dict__.update(entries)
 
         # Set alternative attributes:
-        self._username = self.username # backwards compatibility with v1
+        self._username = self.username  # backwards compatibility with v1
 
         # Base headers and cookies of every session:
         self._headers = dict(headers)
         self._cookies = {
-            "scratchsessionsid" : self.id,
-            "scratchcsrftoken" : "a",
-            "scratchlanguage" : "en",
+            "scratchsessionsid": self.id,
+            "scratchcsrftoken": "a",
+            "scratchlanguage": "en",
             "accept": "application/json",
             "Content-Type": "application/json",
         }
 
-    def _update_from_dict(self, data):
+    def _update_from_dict(self, data: dict):
         # Note: there are a lot more things you can get from this data dict.
         # Maybe it would be a good idea to also store the dict itself?
         # self.data = data
@@ -105,30 +101,40 @@ class Session(BaseSiteComponent):
         self.banned = data["user"]["banned"]
 
         if self.banned:
-            warnings.warn(f"Warning: The account {self._username} you logged in to is BANNED. Some features may not work properly.")
+            warnings.warn(f"Warning: The account {self._username} you logged in to is BANNED. "
+                          f"Some features may not work properly.")
         if self.has_outstanding_email_confirmation:
-            warnings.warn(f"Warning: The account {self._username} you logged is not email confirmed. Some features may not work properly.")
+            warnings.warn(f"Warning: The account {self._username} you logged is not email confirmed. "
+                          f"Some features may not work properly.")
         return True
 
     def connect_linked_user(self) -> 'user.User':
-        '''
-        Gets the user associated with the log in / session.
+        """
+        Gets the user associated with the login / session.
 
         Warning:
             The returned User object is cached. To ensure its attribute are up to date, you need to run .update() on it.
 
         Returns:
-            scratchattach.user.User: Object representing the user associated with the log in / session.
-        '''
+            scratchattach.user.User: Object representing the user associated with the session.
+        """
         if not hasattr(self, "_user"):
             self._user = self.connect_user(self._username)
         return self._user
 
-    def get_linked_user(self):
+    def get_linked_user(self) -> 'user.User':
         # backwards compatibility with v1
-        return self.connect_linked_user() # To avoid inconsistencies with "connect" and "get", this function was renamed
 
-    def set_country(self, country: str="Antarctica"):
+        # To avoid inconsistencies with "connect" and "get", this function was renamed
+        return self.connect_linked_user()
+
+    def set_country(self, country: str = "Antarctica"):
+        """
+        Sets the profile country of the session's associated user
+
+        Arguments:
+            country (str): The country to relocate to
+        """
         requests.post("https://scratch.mit.edu/accounts/settings/",
                       data={"country": country},
                       headers=self._headers, cookies=self._cookies)
@@ -144,10 +150,12 @@ class Session(BaseSiteComponent):
                       data={"email_address": self.new_email_address,
                             "password": password},
                       headers=self._headers, cookies=self._cookies)
+
     @property
-    def new_email_address(self) -> str | None:
+    def new_email_address(self) -> str:
         """
-        Gets the (unconfirmed) email address that this session has requested to transfer to, if any, otherwise the current address.
+        Gets the (unconfirmed) email address that this session has requested to transfer to, if any,
+        otherwise the current address.
 
         Returns:
             str: The email that this session wants to switch to
@@ -161,6 +169,7 @@ class Session(BaseSiteComponent):
         for label_span in soup.find_all("span", {"class": "label"}):
             if label_span.contents[0] == "New Email Address":
                 return label_span.parent.contents[-1].text.strip("\n ")
+
             elif label_span.contents[0] == "Current Email Address":
                 email = label_span.parent.contents[-1].text.strip("\n ")
 
@@ -168,13 +177,13 @@ class Session(BaseSiteComponent):
 
     def logout(self):
         """
-        Sends a logout request to scratch. Might not do anything, might log out this account on other ips/sessions? I am not sure
+        Sends a logout request to scratch. (Might not do anything, might log out this account on other ips/sessions.)
         """
         requests.post("https://scratch.mit.edu/accounts/logout/",
                       headers=self._headers, cookies=self._cookies)
 
-    def messages(self, *, limit=40, offset=0, date_limit=None, filter_by=None):
-        '''
+    def messages(self, *, limit: int = 40, offset: int = 0, date_limit=None, filter_by=None) -> 'activity.Activity':
+        """
         Returns the messages.
 
         Keyword arguments:
@@ -183,98 +192,100 @@ class Session(BaseSiteComponent):
 
         Returns:
             list<scratch.activity.Activity>: List that contains all messages as Activity objects.
-        '''
+        """
         add_params = ""
         if date_limit is not None:
             add_params += f"&dateLimit={date_limit}"
         if filter_by is not None:
             add_params += f"&filter={filter_by}"
+
         data = commons.api_iterative(
             f"https://api.scratch.mit.edu/users/{self._username}/messages",
-            limit = limit, offset = offset, headers = self._headers, cookies = self._cookies, add_params=add_params
+            limit=limit, offset=offset, headers=self._headers, cookies=self._cookies, add_params=add_params
         )
         return commons.parse_object_list(data, activity.Activity, self)
 
-    def admin_messages(self, *, limit=40, offset=0):
+    def admin_messages(self, *, limit=40, offset=0) -> list[dict]:
         """
         Returns your messages sent by the Scratch team (alerts).
         """
         return commons.api_iterative(
             f"https://api.scratch.mit.edu/users/{self._username}/messages/admin",
-            limit = limit, offset = offset, headers = self._headers, cookies = self._cookies
+            limit=limit, offset=offset, headers=self._headers, cookies=self._cookies
         )
 
-
     def clear_messages(self):
-        '''
+        """
         Clears all messages.
-        '''
+        """
         return requests.post(
             "https://scratch.mit.edu/site-api/messages/messages-clear/",
-            headers = self._headers,
-            cookies = self._cookies,
-            timeout = 10,
+            headers=self._headers,
+            cookies=self._cookies,
+            timeout=10,
         ).text
 
-    def message_count(self):
-        '''
+    def message_count(self) -> int:
+        """
         Returns the message count.
 
         Returns:
             int: message count
-        '''
+        """
         return json.loads(requests.get(
             f"https://scratch.mit.edu/messages/ajax/get-message-count/",
-            headers = self._headers,
-            cookies = self._cookies,
-            timeout = 10,
+            headers=self._headers,
+            cookies=self._cookies,
+            timeout=10,
         ).text)["msg_count"]
 
     # Front-page-related stuff:
 
-    def feed(self, *, limit=20, offset=0, date_limit=None):
-        '''
+    def feed(self, *, limit=20, offset=0, date_limit=None) -> list['activity.Activity']:
+        """
         Returns the "What's happening" section (frontpage).
 
         Returns:
             list<scratch.activity.Activity>: List that contains all "What's happening" entries as Activity objects
-        '''
+        """
         add_params = ""
         if date_limit is not None:
             add_params = f"&dateLimit={date_limit}"
         data = commons.api_iterative(
             f"https://api.scratch.mit.edu/users/{self._username}/following/users/activity",
-            limit = limit, offset = offset, headers = self._headers, cookies = self._cookies, add_params=add_params
+            limit=limit, offset=offset, headers=self._headers, cookies=self._cookies, add_params=add_params
         )
         return commons.parse_object_list(data, activity.Activity, self)
 
     def get_feed(self, *, limit=20, offset=0, date_limit=None):
         # for more consistent names, this method was renamed
-        return self.feed(limit=limit, offset=offset, date_limit=date_limit) # for backwards compatibility with v1
+        return self.feed(limit=limit, offset=offset, date_limit=date_limit)  # for backwards compatibility with v1
 
-    def loved_by_followed_users(self, *, limit=40, offset=0):
-        '''
+    def loved_by_followed_users(self, *, limit=40, offset=0) -> list['project.Project']:
+        """
         Returns the "Projects loved by Scratchers I'm following" section (frontpage).
 
         Returns:
-            list<scratchattach.project.Project>: List that contains all "Projects loved by Scratchers I'm following" entries as Project objects
-        '''
+            list<scratchattach.project.Project>: List that contains all "Projects loved by Scratchers I'm following"
+            entries as Project objects
+        """
         data = commons.api_iterative(
             f"https://api.scratch.mit.edu/users/{self._username}/following/users/loves",
-            limit = limit, offset = offset, headers = self._headers, cookies = self._cookies
+            limit=limit, offset=offset, headers=self._headers, cookies=self._cookies
         )
         return commons.parse_object_list(data, project.Project, self)
 
     """
     These methods are disabled because it is unclear if there is any case in which the response is not empty. 
-    def shared_by_followed_users(self, *, limit=40, offset=0):
+    def shared_by_followed_users(self, *, limit=40, offset=0) -> list['project.Project']:
         '''
         Returns the "Projects by Scratchers I'm following" section (frontpage).
         This section is only visible to old accounts (according to the Scratch wiki).
         For newer users, this method will always return an empty list.
 
         Returns:
-            list<scratchattach.project.Project>: List that contains all "Projects loved by Scratchers I'm following" entries as Project objects
+            list<scratchattach.project.Project>: List that contains all "Projects loved by Scratchers I'm following" 
+            entries as Project objects
         '''
         data = commons.api_iterative(
             f"https://api.scratch.mit.edu/users/{self._username}/following/users/projects",
@@ -282,14 +293,15 @@ class Session(BaseSiteComponent):
         )
         return commons.parse_object_list(data, project.Project, self)
 
-    def in_followed_studios(self, *, limit=40, offset=0):
+    def in_followed_studios(self, *, limit=40, offset=0) -> list['project.Project']:
         '''
         Returns the "Projects in studios I'm following" section (frontpage).
         This section is only visible to old accounts (according to the Scratch wiki).
         For newer users, this method will always return an empty list.
 
         Returns:
-            list<scratchattach.project.Project>: List that contains all "Projects loved by Scratchers I'm following" entries as Project objects
+            list<scratchattach.project.Project>: List that contains all "Projects loved by Scratchers I'm following" 
+            entries as Project objects
         '''
         data = commons.api_iterative(
             f"https://api.scratch.mit.edu/users/{self._username}/following/studios/projects",
@@ -299,32 +311,38 @@ class Session(BaseSiteComponent):
 
     # -- Project JSON editing capabilities ---
 
+    @staticmethod
     def connect_empty_project_pb() -> 'project_json_capabilities.ProjectBody':
         pb = project_json_capabilities.ProjectBody()
         pb.from_json(empty_project_json)
         return pb
 
-    def connect_pb_from_dict(project_json:dict) -> 'project_json_capabilities.ProjectBody':
+    @staticmethod
+    def connect_pb_from_dict(project_json: dict) -> 'project_json_capabilities.ProjectBody':
         pb = project_json_capabilities.ProjectBody()
         pb.from_json(project_json)
         return pb
 
+    @staticmethod
     def connect_pb_from_file(path_to_file) -> 'project_json_capabilities.ProjectBody':
         pb = project_json_capabilities.ProjectBody()
+        # noinspection PyProtectedMember
+        # _load_sb3_file starts with an underscore
         pb.from_json(project_json_capabilities._load_sb3_file(path_to_file))
         return pb
 
-    def download_asset(asset_id_with_file_ext, *, filename=None, dir=""):
-        if not (dir.endswith("/") or dir.endswith("\\")):
-            dir = dir+"/"
+    @staticmethod
+    def download_asset(asset_id_with_file_ext, *, filename: str = None, fp=""):
+        if not (fp.endswith("/") or fp.endswith("\\")):
+            fp = fp + "/"
         try:
             if filename is None:
                 filename = str(asset_id_with_file_ext)
             response = requests.get(
-                "https://assets.scratch.mit.edu/"+str(asset_id_with_file_ext),
+                "https://assets.scratch.mit.edu/" + str(asset_id_with_file_ext),
                 timeout=10,
             )
-            open(f"{dir}{filename}", "wb").write(response.content)
+            open(f"{fp}{filename}", "wb").write(response.content)
         except Exception:
             raise (
                 exceptions.FetchError(
@@ -345,62 +363,71 @@ class Session(BaseSiteComponent):
         requests.post(
             f"https://assets.scratch.mit.edu/{asset_id}.{file_ext}",
             headers=self._headers,
-            cookies = self._cookies,
+            cookies=self._cookies,
             data=data,
             timeout=10,
         )
 
     # --- Search ---
 
-    def search_projects(self, *, query="", mode="trending", language="en", limit=40, offset=0):
-        '''
+    def search_projects(self, *, query: str = "", mode: str = "trending", language: str = "en", limit: int = 40,
+                        offset: int = 0) -> list['project.Project']:
+        """
         Uses the Scratch search to search projects.
 
         Keyword arguments:
             query (str): The query that will be searched.
             mode (str): Has to be one of these values: "trending", "popular" or "recent". Defaults to "trending".
-            language (str): A language abbreviation, defaults to "en". (Depending on the language used on the Scratch website, Scratch displays you different results.)
+            language (str): A language abbreviation, defaults to "en".
+                (Depending on the language used on the Scratch website, Scratch displays you different results.)
             limit (int): Max. amount of returned projects.
             offset (int): Offset of the first returned project.
 
         Returns:
             list<scratchattach.project.Project>: List that contains the search results.
-        '''
+        """
         response = commons.api_iterative(
-            f"https://api.scratch.mit.edu/search/projects", limit=limit, offset=offset, add_params=f"&language={language}&mode={mode}&q={query}")
+            f"https://api.scratch.mit.edu/search/projects", limit=limit, offset=offset,
+            add_params=f"&language={language}&mode={mode}&q={query}")
         return commons.parse_object_list(response, project.Project, self)
 
-    def explore_projects(self, *, query="*", mode="trending", language="en", limit=40, offset=0):
-        '''
+    def explore_projects(self, *, query: str = "*", mode: str = "trending", language: str = "en", limit: int = 40,
+                         offset: int = 0) -> list['project.Project']:
+        """
         Gets projects from the explore page.
 
         Keyword arguments:
-            query (str): Specifies the tag of the explore page. To get the projects from the "All" tag, set this argument to "*".
-            mode (str): Has to be one of these values: "trending", "popular" or "recent". Defaults to "trending".
-            language (str): A language abbreviation, defaults to "en". (Depending on the language used on the Scratch website, Scratch displays you different explore pages.)
+            query (str): Specifies the tag of the explore page.
+                To get the projects from the "All" tag, set this argument to "*".
+            mode (str): Has to be one of these values: "trending", "popular" or "recent".
+                Defaults to "trending".
+            language (str): A language abbreviation, defaults to "en".
+                (Depending on the language used on the Scratch website, Scratch displays you different explore pages.)
             limit (int): Max. amount of returned projects.
             offset (int): Offset of the first returned project.
 
         Returns:
             list<scratchattach.project.Project>: List that contains the explore page projects.
-        '''
+        """
         response = commons.api_iterative(
-            f"https://api.scratch.mit.edu/explore/projects", limit=limit, offset=offset, add_params=f"&language={language}&mode={mode}&q={query}")
+            f"https://api.scratch.mit.edu/explore/projects", limit=limit, offset=offset,
+            add_params=f"&language={language}&mode={mode}&q={query}")
         return commons.parse_object_list(response, project.Project, self)
 
     def search_studios(self, *, query="", mode="trending", language="en", limit=40, offset=0):
         if not query:
             raise ValueError("The query can't be empty for search")
         response = commons.api_iterative(
-            f"https://api.scratch.mit.edu/search/studios", limit=limit, offset=offset, add_params=f"&language={language}&mode={mode}&q={query}")
+            f"https://api.scratch.mit.edu/search/studios", limit=limit, offset=offset,
+            add_params=f"&language={language}&mode={mode}&q={query}")
         return commons.parse_object_list(response, studio.Studio, self)
-
 
     def explore_studios(self, *, query="", mode="trending", language="en", limit=40, offset=0):
         if not query:
             raise ValueError("The query can't be empty for explore")
         response = commons.api_iterative(
-            f"https://api.scratch.mit.edu/explore/studios", limit=limit, offset=offset, add_params=f"&language={language}&mode={mode}&q={query}")
+            f"https://api.scratch.mit.edu/explore/studios", limit=limit, offset=offset,
+            add_params=f"&language={language}&mode={mode}&q={query}")
         return commons.parse_object_list(response, studio.Studio, self)
 
     # --- Create project API ---
@@ -420,8 +447,8 @@ class Session(BaseSiteComponent):
             if CREATE_PROJECT_USES[-1] < time.time() - 300:
                 CREATE_PROJECT_USES.pop()
             else:
-                raise exceptions.BadRequest("Rate limit for creating Scratch projects exceeded.\nThis rate limit is enforced by scratchattach, not by the Scratch API.\nFor security reasons, it cannot be turned off.\n\nDon't spam-create projects, it WILL get you banned.")
-                return
+                raise exceptions.BadRequest(
+                    "Rate limit for creating Scratch projects exceeded.\nThis rate limit is enforced by scratchattach, not by the Scratch API.\nFor security reasons, it cannot be turned off.\n\nDon't spam-create projects, it WILL get you banned.")
             CREATE_PROJECT_USES.insert(0, time.time())
 
         if title is None:
@@ -433,7 +460,8 @@ class Session(BaseSiteComponent):
             'title': title,
         }
 
-        response = requests.post('https://projects.scratch.mit.edu/', params=params, cookies=self._cookies, headers=self._headers, json=project_json).json()
+        response = requests.post('https://projects.scratch.mit.edu/', params=params, cookies=self._cookies,
+                                 headers=self._headers, json=project_json).json()
         return self.connect_project(response["content-name"])
 
     def create_studio(self, *, title=None, description: str = None):
@@ -451,8 +479,8 @@ class Session(BaseSiteComponent):
             if CREATE_STUDIO_USES[-1] < time.time() - 300:
                 CREATE_STUDIO_USES.pop()
             else:
-                raise exceptions.BadRequest("Rate limit for creating Scratch studios exceeded.\nThis rate limit is enforced by scratchattach, not by the Scratch API.\nFor security reasons, it cannot be turned off.\n\nDon't spam-create studios, it WILL get you banned.")
-                return
+                raise exceptions.BadRequest(
+                    "Rate limit for creating Scratch studios exceeded.\nThis rate limit is enforced by scratchattach, not by the Scratch API.\nFor security reasons, it cannot be turned off.\n\nDon't spam-create studios, it WILL get you banned.")
             CREATE_STUDIO_USES.insert(0, time.time())
 
         if self.new_scratcher:
@@ -497,19 +525,19 @@ class Session(BaseSiteComponent):
         try:
             targets = requests.get(
                 f"https://scratch.mit.edu/site-api/projects/{filter_arg}/?page={page}&ascsort={ascsort}&descsort={descsort}",
-                headers = headers,
-                cookies = self._cookies,
-                timeout = 10,
+                headers=headers,
+                cookies=self._cookies,
+                timeout=10,
             ).json()
             projects = []
             for target in targets:
                 projects.append(project.Project(
-                    id = target["pk"], _session=self, author_name=self._username,
+                    id=target["pk"], _session=self, author_name=self._username,
                     comments_allowed=None, instructions=None, notes=None,
                     created=target["fields"]["datetime_created"],
                     last_modified=target["fields"]["datetime_modified"],
                     share_date=target["fields"]["datetime_shared"],
-                    thumbnail_url="https:"+target["fields"]["thumbnail_url"],
+                    thumbnail_url="https:" + target["fields"]["thumbnail_url"],
                     favorites=target["fields"]["favorite_count"],
                     loves=target["fields"]["love_count"],
                     remixes=target["fields"]["remixers_count"],
@@ -519,7 +547,7 @@ class Session(BaseSiteComponent):
                 ))
             return projects
         except Exception:
-            raise(exceptions.FetchError)
+            raise (exceptions.FetchError)
 
     def mystuff_studios(self, filter_arg="all", *, page=1, sort_by="", descending=True):
         if descending:
@@ -531,32 +559,31 @@ class Session(BaseSiteComponent):
         try:
             targets = requests.get(
                 f"https://scratch.mit.edu/site-api/galleries/{filter_arg}/?page={page}&ascsort={ascsort}&descsort={descsort}",
-                headers = headers,
-                cookies = self._cookies,
-                timeout = 10,
+                headers=headers,
+                cookies=self._cookies,
+                timeout=10,
             ).json()
             studios = []
             for target in targets:
                 studios.append(studio.Studio(
-                    id = target["pk"], _session=self,
-                    title = target["fields"]["title"],
-                    description = None,
-                    host_id = target["fields"]["owner"]["pk"],
-                    host_name = target["fields"]["owner"]["username"],
-                    open_to_all = None, comments_allowed=None,
-                    image_url = "https:"+target["fields"]["thumbnail_url"],
-                    created = target["fields"]["datetime_created"],
-                    modified = target["fields"]["datetime_modified"],
-                    follower_count = None, manager_count = None,
-                    curator_count = target["fields"]["curators_count"],
-                    project_count = target["fields"]["projecters_count"]
+                    id=target["pk"], _session=self,
+                    title=target["fields"]["title"],
+                    description=None,
+                    host_id=target["fields"]["owner"]["pk"],
+                    host_name=target["fields"]["owner"]["username"],
+                    open_to_all=None, comments_allowed=None,
+                    image_url="https:" + target["fields"]["thumbnail_url"],
+                    created=target["fields"]["datetime_created"],
+                    modified=target["fields"]["datetime_modified"],
+                    follower_count=None, manager_count=None,
+                    curator_count=target["fields"]["curators_count"],
+                    project_count=target["fields"]["projecters_count"]
                 ))
             return studios
         except Exception:
-            raise(exceptions.FetchError)
+            raise (exceptions.FetchError)
 
-
-    def backpack(self,limit=20, offset=0):
+    def backpack(self, limit=20, offset=0):
         '''
         Lists the assets that are in the backpack of the user associated with the session.
 
@@ -565,7 +592,7 @@ class Session(BaseSiteComponent):
         '''
         data = commons.api_iterative(
             f"https://backpack.scratch.mit.edu/{self._username}",
-            limit = limit, offset = offset, headers = self._headers
+            limit=limit, offset=offset, headers=self._headers
         )
         return commons.parse_object_list(data, backpack_asset.BackpackAsset, self)
 
@@ -578,24 +605,26 @@ class Session(BaseSiteComponent):
         '''
         return backpack_asset.BackpackAsset(id=backpack_asset_id, _session=self).delete()
 
-
     def become_scratcher_invite(self):
         """
         If you are a new Scratcher and have been invited for becoming a Scratcher, this API endpoint will provide more info on the invite.
         """
-        return requests.get(f"https://api.scratch.mit.edu/users/{self.username}/invites", headers=self._headers, cookies=self._cookies).json()
+        return requests.get(f"https://api.scratch.mit.edu/users/{self.username}/invites", headers=self._headers,
+                            cookies=self._cookies).json()
 
     # --- Connect classes inheriting from BaseCloud ---
 
-    def connect_cloud(self, project_id, *, CloudClass:Type[_base.BaseCloud]=cloud.ScratchCloud) -> Type[_base.BaseCloud]:
+    # noinspection PyPep8Naming
+    def connect_cloud(self, project_id, *, CloudClass: Type[_base.BaseCloud] = cloud.ScratchCloud) -> Type[
+        _base.BaseCloud]:
         """
-        Connects to a cloud (by default Scratch's cloud) as logged in user.
+        Connects to a cloud (by default Scratch's cloud) as logged-in user.
 
         Args:
             project_id:
         
         Keyword arguments:
-            CloudClass: The class that the returned object should be of. By default this class is scratchattach.cloud.ScratchCloud.
+            CloudClass: The class that the returned object should be of. By default, this class is scratchattach.cloud.ScratchCloud.
 
         Returns:
             Type[scratchattach._base.BaseCloud]: An object representing the cloud of a project. Can be of any class inheriting from BaseCloud.
@@ -609,28 +638,34 @@ class Session(BaseSiteComponent):
         """
         return cloud.ScratchCloud(project_id=project_id, _session=self)
 
-    def connect_tw_cloud(self, project_id, *, purpose="", contact="", cloud_host="wss://clouddata.turbowarp.org") -> 'cloud.TwCloud':
+    def connect_tw_cloud(self, project_id, *, purpose="", contact="",
+                         cloud_host="wss://clouddata.turbowarp.org") -> 'cloud.TwCloud':
         """
         Returns:
             scratchattach.cloud.TwCloud: An object representing the TurboWarp cloud of a project.
         """
-        return cloud.TwCloud(project_id=project_id, purpose=purpose, contact=contact, cloud_host=cloud_host, _session=self)
+        return cloud.TwCloud(project_id=project_id, purpose=purpose, contact=contact, cloud_host=cloud_host,
+                             _session=self)
 
     # --- Connect classes inheriting from BaseSiteComponent ---
 
-    def _make_linked_object(self, identificator_name, identificator, Class, NotFoundException):
+    # noinspection PyPep8Naming
+    # Class is camelcase here
+    def _make_linked_object(self, identificator_name, identificator, Class: BaseSiteComponent,
+                            NotFoundException: Exception):
         """
         The Session class doesn't save the login in a ._session attribute, but IS the login ITSELF.
 
-        Therefore the _make_linked_object method has to be adjusted
+        Therefore, the _make_linked_object method has to be adjusted
         to get it to work for in the Session class.
 
         Class must inherit from BaseSiteComponent
         """
+        # noinspection PyProtectedMember
+        # _get_object is protected
         return commons._get_object(identificator_name, identificator, Class, NotFoundException, self)
 
-
-    def connect_user(self, username) -> 'user.User':
+    def connect_user(self, username: str) -> 'user.User':
         """
         Gets a user using this session, connects the session to the User object to allow authenticated actions
 
@@ -642,7 +677,7 @@ class Session(BaseSiteComponent):
         """
         return self._make_linked_object("username", username, user.User, exceptions.UserNotFound)
 
-    def find_username_from_id(self, user_id:int):
+    def find_username_from_id(self, user_id: int):
         """
         Warning:
             Every time this functions is run, a comment on your profile is posted and deleted. Therefore you shouldn't run this too often.
@@ -654,7 +689,8 @@ class Session(BaseSiteComponent):
         try:
             comment = you.post_comment("scratchattach", commentee_id=int(user_id))
         except exceptions.CommentPostFailure:
-            raise exceptions.BadRequest("After posting a comment, you need to wait 10 seconds before you can connect users by id again.")
+            raise exceptions.BadRequest(
+                "After posting a comment, you need to wait 10 seconds before you can connect users by id again.")
         except exceptions.BadRequest:
             raise exceptions.UserNotFound("Invalid user id")
         except Exception as e:
@@ -667,8 +703,7 @@ class Session(BaseSiteComponent):
             raise exceptions.UserNotFound()
         return username
 
-
-    def connect_user_by_id(self, user_id:int) -> 'user.User':
+    def connect_user_by_id(self, user_id: int) -> 'user.User':
         """
         Gets a user using this session, connects the session to the User object to allow authenticated actions
 
@@ -686,7 +721,8 @@ class Session(BaseSiteComponent):
         Returns:
             scratchattach.user.User: An object that represents the requested user and allows you to perform actions on the user (like user.follow)
         """
-        return self._make_linked_object("username", self.find_username_from_id(user_id), user.User, exceptions.UserNotFound)
+        return self._make_linked_object("username", self.find_username_from_id(user_id), user.User,
+                                        exceptions.UserNotFound)
 
     def connect_project(self, project_id) -> 'project.Project':
         """
@@ -734,7 +770,8 @@ sess
         Returns:
             scratchattach.classroom.Classroom: An object representing the requested classroom
         """
-        return self._make_linked_object("classtoken", int(class_token), classroom.Classroom, exceptions.ClassroomNotFound)
+        return self._make_linked_object("classtoken", int(class_token), classroom.Classroom,
+                                        exceptions.ClassroomNotFound)
 
     def connect_topic(self, topic_id) -> 'forum.ForumTopic':
         """
@@ -748,7 +785,6 @@ sess
             scratchattach.forum.ForumTopic: An object that represents the requested forum topic
         """
         return self._make_linked_object("id", int(topic_id), forum.ForumTopic, exceptions.ForumContentNotFound)
-
 
     def connect_topic_list(self, category_id, *, page=1):
 
@@ -767,7 +803,8 @@ sess
         """
 
         try:
-            response = requests.get(f"https://scratch.mit.edu/discuss/{category_id}/?page={page}", headers=self._headers, cookies=self._cookies)
+            response = requests.get(f"https://scratch.mit.edu/discuss/{category_id}/?page={page}",
+                                    headers=self._headers, cookies=self._cookies)
             soup = BeautifulSoup(response.content, 'html.parser')
         except Exception as e:
             raise exceptions.FetchError(str(e))
@@ -795,7 +832,10 @@ sess
 
                 last_updated = columns[3].split(" ")[0] + " " + columns[3].split(" ")[1]
 
-                return_topics.append(forum.ForumTopic(_session=self, id=int(topic_id), title=title, category_name=category_name, last_updated=last_updated, reply_count=int(columns[1]), view_count=int(columns[2])))
+                return_topics.append(
+                    forum.ForumTopic(_session=self, id=int(topic_id), title=title, category_name=category_name,
+                                     last_updated=last_updated, reply_count=int(columns[1]),
+                                     view_count=int(columns[2])))
             return return_topics
         except Exception as e:
             raise exceptions.ScrapeError(str(e))
@@ -804,28 +844,36 @@ sess
 
     def connect_message_events(self, *, update_interval=2) -> 'message_events.MessageEvents':
         # shortcut for connect_linked_user().message_events()
-        return message_events.MessageEvents(user.User(username=self.username, _session=self), update_interval=update_interval)
+        return message_events.MessageEvents(user.User(username=self.username, _session=self),
+                                            update_interval=update_interval)
 
     def connect_filterbot(self, *, log_deletions=True) -> 'filterbot.Filterbot':
         return filterbot.Filterbot(user.User(username=self.username, _session=self), log_deletions=log_deletions)
 
+
 # ------ #
 
-def login_by_id(session_id, *, username=None, password=None, xtoken=None) -> Session:
+def login_by_id(session_id: str, *, username: str = None, password: str = None, xtoken=None) -> Session:
     """
     Creates a session / log in to the Scratch website with the specified session id.
     Structured similarly to Session._connect_object method.
 
     Args:
         session_id (str)
-        password (str)
 
     Keyword arguments:
-        timeout (int): Optional, but recommended. Specify this when the Python environment's IP address is blocked by Scratch's API, but you still want to use cloud variables.
+        username (str)
+        password (str)
+        xtoken (str)
 
     Returns:
-        scratchattach.session.Session: An object that represents the created log in / session
+        scratchattach.session.Session: An object that represents the created login / session
     """
+    # Removed this from docstring since it doesn't exist:
+    # timeout (int): Optional, but recommended.
+    # Specify this when the Python environment's IP address is blocked by Scratch's API,
+    # but you still want to use cloud variables.
+
     # Generate session_string (a scratchattach-specific authentication method)
     if password is not None:
         session_data = dict(session_id=session_id, username=username, password=password)
@@ -833,20 +881,28 @@ def login_by_id(session_id, *, username=None, password=None, xtoken=None) -> Ses
     else:
         session_string = None
     _session = Session(id=session_id, username=username, session_string=session_string, xtoken=xtoken)
+
     try:
         status = _session.update()
     except Exception as e:
         status = False
-        print(f"Key error at key "+str(e)+" when reading scratch.mit.edu/session API response")
+        warnings.warn(f"Key error at key {e} when reading scratch.mit.edu/session API response")
+
     if status is not True:
         if _session.xtoken is None:
             if _session.username is None:
-                print(f"Warning: Logged in by id, but couldn't fetch XToken. Make sure the provided session id is valid. Setting cloud variables can still work if you provide a `username='username'` keyword argument to the sa.login_by_id function")
+                warnings.warn("Warning: Logged in by id, but couldn't fetch XToken. "
+                              "Make sure the provided session id is valid. "
+                              "Setting cloud variables can still work if you provide a "
+                              "`username='username'` keyword argument to the sa.login_by_id function")
             else:
-                print(f"Warning: Logged in by id, but couldn't fetch XToken. Make sure the provided session id is valid.")
+                warnings.warn("Warning: Logged in by id, but couldn't fetch XToken. "
+                              "Make sure the provided session id is valid.")
         else:
-            print(f"Warning: Logged in by id, but couldn't fetch session info. This won't affect any other features.")
+            warnings.warn("Warning: Logged in by id, but couldn't fetch session info. "
+                          "This won't affect any other features.")
     return _session
+
 
 def login(username, password, *, timeout=10) -> Session:
     """
@@ -864,7 +920,7 @@ def login(username, password, *, timeout=10) -> Session:
         timeout (int): Timeout for the request to Scratch's login API (in seconds). Defaults to 10.
 
     Returns:
-        scratchattach.session.Session: An object that represents the created log in / session
+        scratchattach.session.Session: An object that represents the created login / session
     """
 
     # Post request to login API:
@@ -873,7 +929,7 @@ def login(username, password, *, timeout=10) -> Session:
     _headers["Cookie"] = "scratchcsrftoken=a;scratchlanguage=en;"
     request = requests.post(
         "https://scratch.mit.edu/login/", data=data, headers=_headers,
-        timeout = timeout,
+        timeout=timeout,
     )
     try:
         session_id = str(re.search('"(.*)"', request.headers["Set-Cookie"]).group())
@@ -886,11 +942,12 @@ def login(username, password, *, timeout=10) -> Session:
 
 
 def login_by_session_string(session_string) -> Session:
-    session_string = base64.b64decode(session_string).decode() # unobfuscate
+    session_string = base64.b64decode(session_string).decode()  # unobfuscate
     session_data = json.loads(session_string)
     try:
         assert session_data.get("session_id")
-        return login_by_id(session_data["session_id"], username=session_data.get("username"), password=session_data.get("password"))
+        return login_by_id(session_data["session_id"], username=session_data.get("username"),
+                           password=session_data.get("password"))
     except Exception:
         pass
     try:

--- a/scratchattach/site/session.py
+++ b/scratchattach/site/session.py
@@ -132,15 +132,6 @@ class Session(BaseSiteComponent):
                       data={"country": country},
                       headers=self._headers, cookies=self._cookies)
 
-    def change_password(self, old_password: str, new_password: str = None):
-        if new_password is None or new_password == old_password:
-            return
-        requests.post("https://scratch.mit.edu/accounts/password_change/",
-                      data={"old_password": old_password,
-                            "new_password1": new_password,
-                            "new_password2": new_password},
-                      headers=self._headers, cookies=self._cookies)
-
     def resend_email(self, password: str):
         """
         Sends a request to resend a confirmation email for this session's account
@@ -152,20 +143,6 @@ class Session(BaseSiteComponent):
                       data={"email_address": self.new_email_address,
                             "password": password},
                       headers=self._headers, cookies=self._cookies)
-
-    def change_email(self, new_email: str, password: str):
-        """
-        Sends a request to change the email of this session
-
-        Keyword arguments:
-            new_email (str): The email you want to switch to
-            password (str): Password associated with the session (not stored)
-        """
-        requests.post("https://scratch.mit.edu/accounts/email_change/",
-                      data={"email_address": new_email,
-                            "password": password},
-                      headers=self._headers, cookies=self._cookies)
-
     @property
     def new_email_address(self) -> str | None:
         """
@@ -187,23 +164,7 @@ class Session(BaseSiteComponent):
                 email = label_span.parent.contents[-1].text.strip("\n ")
 
         return email
-
-    def delete_account(self, *, password: str, delete_projects: bool = False):
-        """
-        !!! Dangerous !!!
-        Sends a request to delete the account that is associated with this session.
-        You can cancel the deletion simply by logging back in (including using sa.login(username, password))
-
-        Keyword arguments:
-            password (str): The password associated with the account
-            delete_projects (bool): Whether to delete all the projects as well
-        """
-        requests.post("https://scratch.mit.edu/accounts/settings/delete_account/",
-                      data={
-                          "delete_state": "delbyusrwproj" if delete_projects else "delbyusr",
-                          "password": password
-                      }, headers=self._headers, cookies=self._cookies)
-
+    
     def logout(self):
         """
         Sends a logout request to scratch. Might not do anything, might log out this account on other ips/sessions? I am not sure

--- a/scratchattach/site/user.py
+++ b/scratchattach/site/user.py
@@ -269,7 +269,7 @@ class User(BaseSiteComponent):
             list<projects.projects.Project>: The user's shared projects
         """
         _projects = commons.api_iterative(
-            f"https://api.scratch.mit.edu/users/{self.username}/projects/", limit=limit, offset=offset, headers = self._headers)
+            f"https://api.scratch.mit.edu/users/{self.username}/projects/", limit=limit, offset=offset, _headers= self._headers)
         for p in _projects:
             p["author"] = {"username":self.username}
         return commons.parse_object_list(_projects, project.Project, self._session)
@@ -391,7 +391,7 @@ class User(BaseSiteComponent):
             list<projects.projects.Project>: The user's favorite projects
         """
         _projects = commons.api_iterative(
-            f"https://api.scratch.mit.edu/users/{self.username}/favorites/", limit=limit, offset=offset, headers = self._headers)
+            f"https://api.scratch.mit.edu/users/{self.username}/favorites/", limit=limit, offset=offset, _headers= self._headers)
         return commons.parse_object_list(_projects, project.Project, self._session)
 
     def favorites_count(self):
@@ -420,7 +420,7 @@ class User(BaseSiteComponent):
         """
         self._assert_permission()
         _projects = commons.api_iterative(
-            f"https://api.scratch.mit.edu/users/{self.username}/projects/recentlyviewed", limit=limit, offset=offset, headers = self._headers)
+            f"https://api.scratch.mit.edu/users/{self.username}/projects/recentlyviewed", limit=limit, offset=offset, _headers= self._headers)
         return commons.parse_object_list(_projects, project.Project, self._session)
 
     def set_bio(self, text):

--- a/scratchattach/utils/commons.py
+++ b/scratchattach/utils/commons.py
@@ -81,6 +81,7 @@ def api_iterative_data(fetch_func, limit, offset, max_req_limit=40, unpack=True)
     api_data = api_data[:limit]
     return api_data
 
+
 def api_iterative(
     url, *, limit, offset, max_req_limit=40, add_params="", headers=headers, cookies={}
 ):
@@ -92,12 +93,12 @@ def api_iterative(
     if limit < 0:
         raise exceptions.BadRequest("limit parameter must be >= 0")
     
-    def fetch(o, l):
+    def fetch(off, lim):
         """
-        Performs a singla API request
+        Performs a single API request
         """
         resp = requests.get(
-            f"{url}?limit={l}&offset={o}{add_params}", headers=headers, cookies=cookies, timeout=10
+            f"{url}?limit={lim}&offset={off}{add_params}", headers=headers, cookies=cookies, timeout=10
         ).json()
         if not resp:
             return None
@@ -109,6 +110,7 @@ def api_iterative(
         fetch, limit, offset, max_req_limit=max_req_limit, unpack=True
     )
     return api_data
+
 
 def _get_object(identificator_name, identificator, Class, NotFoundException, session=None):
     # Interal function: Generalization of the process ran by get_user, get_studio etc.

--- a/scratchattach/utils/commons.py
+++ b/scratchattach/utils/commons.py
@@ -1,9 +1,13 @@
 """v2 ready: Common functions used by various internal modules"""
 from types import FunctionType
-from typing import Final, Any
+from typing import Final, Any, TYPE_CHECKING
 
 from . import exceptions
 from .requests import Requests as requests
+
+if TYPE_CHECKING:
+    # Having to do this is quite inelegant, but this is commons.py, so this is done to avoid cyclic imports
+    from ..site._base import BaseSiteComponent
 
 headers: Final = {
     "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
@@ -60,7 +64,7 @@ empty_project_json: Final = {
 }
 
 
-def api_iterative_data(fetch_func: 'FunctionType', limit: int, offset: int, max_req_limit: int = 40,
+def api_iterative_data(fetch_func: FunctionType, limit: int, offset: int, max_req_limit: int = 40,
                        unpack: bool = True):
     """
     Iteratively gets data by calling fetch_func with a moving offset and a limit.
@@ -123,7 +127,7 @@ def api_iterative(url: str, *, limit: int, offset: int, max_req_limit: int = 40,
     return api_data
 
 
-def _get_object(identificator_name, identificator, Class, NotFoundException, session=None):
+def _get_object(identificator_name, identificator, Class, NotFoundException, session=None) -> 'BaseSiteComponent':
     # Internal function: Generalization of the process ran by get_user, get_studio etc.
     # Builds an object of class that is inheriting from BaseSiteComponent
     # # Class must inherit from BaseSiteComponent

--- a/scratchattach/utils/commons.py
+++ b/scratchattach/utils/commons.py
@@ -1,9 +1,11 @@
 """v2 ready: Common functions used by various internal modules"""
+from types import FunctionType
+from typing import Final, Any
 
 from . import exceptions
 from .requests import Requests as requests
 
-headers = {
+headers: Final = {
     "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
                   "(KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36",
     "x-csrftoken": "a",
@@ -11,7 +13,7 @@ headers = {
     "referer": "https://scratch.mit.edu",
 }  # headers recommended for accessing API endpoints that don't require verification
 
-empty_project_json = {
+empty_project_json: Final = {
     'targets': [
         {
             'isStage': True,
@@ -58,39 +60,42 @@ empty_project_json = {
 }
 
 
-def api_iterative_data(fetch_func, limit, offset, max_req_limit=40, unpack=True):
+def api_iterative_data(fetch_func: 'FunctionType', limit: int, offset: int, max_req_limit: int = 40,
+                       unpack: bool = True):
     """
     Iteratively gets data by calling fetch_func with a moving offset and a limit.
     Once fetch_func returns None, the retrieval is completed.
     """
     if limit is None:
         limit = max_req_limit
+
     end = offset + limit
     api_data = []
     for offs in range(offset, end, max_req_limit):
-        d = fetch_func(
-            offs, max_req_limit
-        )  # Mimick actual scratch by only requesting the max amount
-        if d is None:
+        # Mimic actual scratch by only requesting the max amount
+        data = fetch_func(offs, max_req_limit)
+        if data is None:
             break
+
         if unpack:
-            api_data.extend(d)
+            api_data.extend(data)
         else:
-            api_data.append(d)
-        if len(d) < max_req_limit:
+            api_data.append(data)
+
+        if len(data) < max_req_limit:
             break
+
     api_data = api_data[:limit]
     return api_data
 
 
-def api_iterative(
-        url, *, limit, offset, max_req_limit=40, add_params="", _headers=None, cookies=None
-):
+def api_iterative(url: str, *, limit: int, offset: int, max_req_limit: int = 40, add_params: str = "",
+                  _headers: dict = None, cookies: dict = None):
     """
     Function for getting data from one of Scratch's iterative JSON API endpoints (like /users/<user>/followers, or /users/<user>/projects)
     """
     if _headers is None:
-        _headers = headers
+        _headers = headers.copy()
     if cookies is None:
         cookies = {}
 
@@ -99,7 +104,7 @@ def api_iterative(
     if limit < 0:
         raise exceptions.BadRequest("limit parameter must be >= 0")
 
-    def fetch(off, lim):
+    def fetch(off: int, lim: int):
         """
         Performs a single API request
         """
@@ -109,7 +114,7 @@ def api_iterative(
         if not resp:
             return None
         if resp == {"code": "BadRequest", "message": ""}:
-            raise exceptions.BadRequest("the passed arguments are invalid")
+            raise exceptions.BadRequest("The passed arguments are invalid")
         return resp
 
     api_data = api_iterative_data(
@@ -119,7 +124,7 @@ def api_iterative(
 
 
 def _get_object(identificator_name, identificator, Class, NotFoundException, session=None):
-    # Interal function: Generalization of the process ran by get_user, get_studio etc.
+    # Internal function: Generalization of the process ran by get_user, get_studio etc.
     # Builds an object of class that is inheriting from BaseSiteComponent
     # # Class must inherit from BaseSiteComponent
     try:
@@ -140,16 +145,16 @@ def _get_object(identificator_name, identificator, Class, NotFoundException, ses
         else:
             return _object
     except KeyError as e:
-        raise NotFoundException("Key error at key " + str(e) + " when reading API response")
+        raise NotFoundException(f"Key error at key {e} when reading API response")
     except Exception as e:
         raise e
 
 
-def webscrape_count(raw, text_before, text_after):
-    return int(raw.split(text_before)[1].split(text_after)[0])
+def webscrape_count(raw, text_before, text_after, cls: type = int) -> int | Any:
+    return cls(raw.split(text_before)[1].split(text_after)[0])
 
 
-def parse_object_list(raw, Class, session=None, primary_key="id"):
+def parse_object_list(raw, Class, session=None, primary_key="id") -> list:
     results = []
     for raw_dict in raw:
         try:

--- a/scratchattach/utils/exceptions.py
+++ b/scratchattach/utils/exceptions.py
@@ -18,7 +18,6 @@ class Unauthenticated(Exception):
     def __init__(self, message=""):
         self.message = "No login / session connected.\n\nThe object on which the method was called was created using scratchattach.get_xyz()\nUse session.connect_xyz() instead (xyz is a placeholder for user / project / cloud / ...).\n\nMore information: https://scratchattach.readthedocs.io/en/latest/scratchattach.html#scratchattach.utils.exceptions.Unauthenticated"
         super().__init__(self.message)
-    pass
 
 
 class Unauthorized(Exception):
@@ -29,10 +28,11 @@ class Unauthorized(Exception):
     """
 
     def __init__(self, message=""):
-        self.message = "The user corresponding to the connected login / session is not allowed to perform this action."
+        self.message = (
+            f"The user corresponding to the connected login / session is not allowed to perform this action. "
+            f"{message}")
         super().__init__(self.message)
 
-    pass
 
 class XTokenError(Exception):
     """
@@ -42,6 +42,7 @@ class XTokenError(Exception):
     """
 
     pass
+
 
 # Not found errors:
 
@@ -60,6 +61,7 @@ class ProjectNotFound(Exception):
 
     pass
 
+
 class ClassroomNotFound(Exception):
     """
     Raised when a non-existent Classroom is requested.
@@ -75,14 +77,17 @@ class StudioNotFound(Exception):
 
     pass
 
+
 class ForumContentNotFound(Exception):
     """
     Raised when a non-existent forum topic / post is requested.
     """
     pass
 
+
 class CommentNotFound(Exception):
     pass
+
 
 # API errors:
 
@@ -95,12 +100,14 @@ class LoginFailure(Exception):
 
     pass
 
+
 class FetchError(Exception):
     """
     Raised when getting information from the Scratch API fails. This can have various reasons. Make sure all provided arguments are valid.
     """
 
     pass
+
 
 class BadRequest(Exception):
     """
@@ -117,6 +124,7 @@ class Response429(Exception):
 
     pass
 
+
 class CommentPostFailure(Exception):
     """
     Raised when a comment fails to post. This can have various reasons.
@@ -124,11 +132,13 @@ class CommentPostFailure(Exception):
 
     pass
 
+
 class APIError(Exception):
     """
     For API errors that can't be classified into one of the above errors
     """
     pass
+
 
 class ScrapeError(Exception):
     """
@@ -137,9 +147,10 @@ class ScrapeError(Exception):
 
     pass
 
+
 # Cloud / encoding errors:
 
-class ConnectionError(Exception):
+class CloudConnectionError(Exception):
     """
     Raised when connecting to Scratch's cloud server fails. This can have various reasons.
     """
@@ -172,10 +183,10 @@ class RequestNotFound(Exception):
 
     pass
 
+
 # Websocket server errors:
 
 class WebsocketServerError(Exception):
-
     """
     Raised when the self-hosted cloud websocket server fails to start.
     """

--- a/scratchattach/utils/requests.py
+++ b/scratchattach/utils/requests.py
@@ -9,9 +9,9 @@ class Requests:
     """
 
     @staticmethod
-    def check_response(r : requests.Response):
+    def check_response(r: requests.Response):
         if r.status_code == 403 or r.status_code == 401:
-            raise exceptions.Unauthorized
+            raise exceptions.Unauthorized(f"Request content: {r.content}")
         if r.status_code == 500:
             raise exceptions.APIError("Internal Scratch server error")
         if r.status_code == 429:


### PR DESCRIPTION
# create_studio()
Added the `Session.create_studio()` function to create studios to solve [an issue](https://github.com/TimMcCool/scratchattach/issues/277). I copy+pasted rate limit code from `Session.create_project()`. Also added title/desc settings to make it more convenient

# exceptions
- Now using the msg argument in `exceptions.Unauthorized()` so that you can add more detail to the exception if need be. When receiving a 403/401 status code in the `requests` wrapper, it will now print the request  content which will sometimes be more descriptive than simply: "You are unauthorised"
- Renamed `ConnectionError` to `CloudConnectionError` since `ConnectionError` is actually a builtin error

### Extra Note(s)
- In `cloud_requests.py`, I fixed a typo of `self.call_even`, changing it to `self.call_event`. In the rare case this is intentional, now you know
- Also it looks like I pressed ctrl-alt-l again...

# Type hints + other stuff
I have also added a ton of type hints (hopefully they work)
In addition, I have created a few abstract/default methods for some of the base classes. It seems to be working.

Potentially, you may want to merge an old version of this branch, or i should use github better