### PR TITLE
Added create_studio + did a little with exceptions

### DIFF
--- a/scratchattach/cloud/_base.py
+++ b/scratchattach/cloud/_base.py
@@ -100,7 +100,7 @@ class BaseCloud(ABC):
                         self.websocket.send(json.dumps(packet) + "\n")
                     except Exception:
                         self.active_connection = False
-                        raise exceptions.ConnectionError(f"Sending packet failed three times in a row: {packet}")
+                        raise exceptions.CloudConnectionError(f"Sending packet failed three times in a row: {packet}")
 
     def _send_packet_list(self, packet_list):
         packet_string = "".join([json.dumps(packet) + "\n" for packet in packet_list])
@@ -126,7 +126,7 @@ class BaseCloud(ABC):
                         self.websocket.send(packet_string)
                     except Exception:
                         self.active_connection = False
-                        raise exceptions.ConnectionError(f"Sending packet list failed four times in a row: {packet_list}")
+                        raise exceptions.CloudConnectionError(f"Sending packet list failed four times in a row: {packet_list}")
 
     def _handshake(self):
         packet = {"method": "handshake", "user": self.username, "project_id": self.project_id}

--- a/scratchattach/eventhandlers/cloud_requests.py
+++ b/scratchattach/eventhandlers/cloud_requests.py
@@ -167,8 +167,8 @@ class CloudRequests(CloudEvents):
     def _set_FROM_HOST_var(self, value):
         try:
             self.cloud.set_var(f"FROM_HOST_{self.used_cloud_vars[self.current_var]}", value)
-        except exceptions.ConnectionError:
-            self.call_even("on_disconnect")
+        except exceptions.CloudConnectionError:
+            self.call_event("on_disconnect")
         except Exception as e:
             print("scratchattach: internal error while responding (please submit a bug report on GitHub):", e)
         self.current_var += 1

--- a/scratchattach/site/session.py
+++ b/scratchattach/site/session.py
@@ -438,7 +438,7 @@ class Session(BaseSiteComponent):
 
     def create_studio(self, *, title=None, description: str = None):
         """
-        Create a project on the scratch website
+        Create a studio on the scratch website
 
         Warning:
             Don't spam this method - it WILL get you banned from Scratch.

--- a/scratchattach/utils/exceptions.py
+++ b/scratchattach/utils/exceptions.py
@@ -18,7 +18,6 @@ class Unauthenticated(Exception):
     def __init__(self, message=""):
         self.message = "No login / session connected.\n\nThe object on which the method was called was created using scratchattach.get_xyz()\nUse session.connect_xyz() instead (xyz is a placeholder for user / project / cloud / ...).\n\nMore information: https://scratchattach.readthedocs.io/en/latest/scratchattach.html#scratchattach.utils.exceptions.Unauthenticated"
         super().__init__(self.message)
-    pass
 
 
 class Unauthorized(Exception):
@@ -29,10 +28,11 @@ class Unauthorized(Exception):
     """
 
     def __init__(self, message=""):
-        self.message = "The user corresponding to the connected login / session is not allowed to perform this action."
+        self.message = (
+            f"The user corresponding to the connected login / session is not allowed to perform this action. "
+            f"{message}")
         super().__init__(self.message)
 
-    pass
 
 class XTokenError(Exception):
     """
@@ -42,6 +42,7 @@ class XTokenError(Exception):
     """
 
     pass
+
 
 # Not found errors:
 
@@ -60,6 +61,7 @@ class ProjectNotFound(Exception):
 
     pass
 
+
 class ClassroomNotFound(Exception):
     """
     Raised when a non-existent Classroom is requested.
@@ -75,14 +77,17 @@ class StudioNotFound(Exception):
 
     pass
 
+
 class ForumContentNotFound(Exception):
     """
     Raised when a non-existent forum topic / post is requested.
     """
     pass
 
+
 class CommentNotFound(Exception):
     pass
+
 
 # API errors:
 
@@ -95,12 +100,14 @@ class LoginFailure(Exception):
 
     pass
 
+
 class FetchError(Exception):
     """
     Raised when getting information from the Scratch API fails. This can have various reasons. Make sure all provided arguments are valid.
     """
 
     pass
+
 
 class BadRequest(Exception):
     """
@@ -117,6 +124,7 @@ class Response429(Exception):
 
     pass
 
+
 class CommentPostFailure(Exception):
     """
     Raised when a comment fails to post. This can have various reasons.
@@ -124,11 +132,13 @@ class CommentPostFailure(Exception):
 
     pass
 
+
 class APIError(Exception):
     """
     For API errors that can't be classified into one of the above errors
     """
     pass
+
 
 class ScrapeError(Exception):
     """
@@ -137,9 +147,10 @@ class ScrapeError(Exception):
 
     pass
 
+
 # Cloud / encoding errors:
 
-class ConnectionError(Exception):
+class CloudConnectionError(Exception):
     """
     Raised when connecting to Scratch's cloud server fails. This can have various reasons.
     """
@@ -172,10 +183,10 @@ class RequestNotFound(Exception):
 
     pass
 
+
 # Websocket server errors:
 
 class WebsocketServerError(Exception):
-
     """
     Raised when the self-hosted cloud websocket server fails to start.
     """

--- a/scratchattach/utils/requests.py
+++ b/scratchattach/utils/requests.py
@@ -9,9 +9,9 @@ class Requests:
     """
 
     @staticmethod
-    def check_response(r : requests.Response):
+    def check_response(r: requests.Response):
         if r.status_code == 403 or r.status_code == 401:
-            raise exceptions.Unauthorized
+            raise exceptions.Unauthorized(f"Request content: {r.content}")
         if r.status_code == 500:
             raise exceptions.APIError("Internal Scratch server error")
         if r.status_code == 429:


### PR DESCRIPTION
# create_studio()
Added the `Session.create_studio()` function to create studios to solve [an issue](https://github.com/TimMcCool/scratchattach/issues/277) (#277). I copy+pasted rate limit code from `Session.create_project()`. Also added title/desc settings to make it more convenient

# exceptions
- Now using the msg argument in `exceptions.Unauthorized()` so that you can add more detail to the exception if need be. When receiving a 403/401 status code in the `requests` wrapper, it will now print the request  content which will sometimes be more descriptive than simply: "You are unauthorised"
- Renamed `ConnectionError` to `CloudConnectionError` since `ConnectionError` is actually a builtin error

### Extra Note(s)
- In `cloud_requests.py`, I fixed a typo of `self.call_even`, changing it to `self.call_event`. In the rare case this is intentional, now you know
- Also it looks like I pressed ctrl-alt-l again...