### PR TITLE
Fix reporting comments on profiles

### DIFF
--- a/scratchattach/site/user.py
+++ b/scratchattach/site/user.py
@@ -635,7 +635,7 @@ class User(BaseSiteComponent):
         Args:
             comment_id: The id of the comment that should be reported
         """
-        self._assert_permission()
+        self._assert_auth()
         return requests.post(
             f"https://scratch.mit.edu/site-api/comments/user/{self.username}/rep/",
             headers = headers,


### PR DESCRIPTION
I made report_comment use _assert_auth instead of _assert_permission so that you can report comments if you're not the profile owner.

I haven't tested this yet. I will test it next time I see spammers on griffpatch's profile. Additionally, due to this bug, it seems like the report function has never been tested, so I'll compare the network output to that when I do it in browser.