### PR TITLE
make sa.User.studios_following_count() use the right endpoint

### DIFF
--- a/scratchattach/site/user.py
+++ b/scratchattach/site/user.py
@@ -260,7 +260,7 @@ class User(BaseSiteComponent):
 
     def studios_following_count(self):
         text = requests.get(
-            f"https://scratch.mit.edu/users/{self.username}/studios/",
+            f"https://scratch.mit.edu/users/{self.username}/studios_following/",
             headers = self._headers
         ).text
         return commons.webscrape_count(text, "Studios I Follow (", ")")


### PR DESCRIPTION
Currently, this uses https://scratch.mit.edu/users/{user}/studios/, and running this function will throw an error. This makes it use https://scratch.mit.edu/users/{user}/studios_following/