### PR TITLE
Classroom property (solves #382)

### DIFF
--- a/scratchattach/site/classroom.py
+++ b/scratchattach/site/classroom.py
@@ -30,10 +30,11 @@ class Classroom(BaseSiteComponent):
         else:
             raise KeyError(f"No class id or token provided! Entries: {entries}")
 
-        # Set attributes every Project object needs to have:
+        # Set attributes every Classroom object needs to have:
         self._session: Session = None
         self.id = None
         self.classtoken = None
+        self.is_closed = False
 
         self.__dict__.update(entries)
 
@@ -49,7 +50,6 @@ class Classroom(BaseSiteComponent):
         self._json_headers = dict(self._headers)
         self._json_headers["accept"] = "application/json"
         self._json_headers["Content-Type"] = "application/json"
-        self.is_closed = False
 
     def __repr__(self) -> str:
         return f"classroom called {self.title!r}"

--- a/scratchattach/site/user.py
+++ b/scratchattach/site/user.py
@@ -3,22 +3,26 @@ from __future__ import annotations
 
 import json
 import random
+import re
 import string
 from datetime import datetime, timezone
 
+from bs4 import BeautifulSoup
+
+from ._base import BaseSiteComponent
 from ..eventhandlers import message_events
-from . import project
+
+from ..utils import commons
 from ..utils import exceptions
+from ..utils.commons import headers
+from ..utils.requests import Requests as requests
+
+from . import project
 from . import studio
 from . import forum
-from bs4 import BeautifulSoup
-from ._base import BaseSiteComponent
-from ..utils.commons import headers
-from ..utils import commons
 from . import comment
 from . import activity
-
-from ..utils.requests import Requests as requests
+from . import classroom
 
 class Verificator:
 

--- a/scratchattach/site/user.py
+++ b/scratchattach/site/user.py
@@ -140,11 +140,15 @@ class User(BaseSiteComponent):
 
             details = soup.find("p", {"class": "profile-details"})
 
-            class_name, class_id = None, None
+            class_name, class_id, is_closed = None, None, None
             for a in details.find_all("a"):
                 href = a.get("href")
                 if re.match(r"/classes/\d*/", href):
                     class_name = a.text.strip()[len("Student of: "):]
+                    is_closed = class_name.endswith("\n            (ended)") # as this has a \n, we can be sure
+                    if is_closed:
+                        class_name = class_name[:-7].strip()
+
                     class_id = href.split('/')[2]
                     break
 
@@ -152,7 +156,8 @@ class User(BaseSiteComponent):
                 self._classroom = True, classroom.Classroom(
                     _session=self,
                     id=class_id,
-                    title=class_name
+                    title=class_name,
+                    is_closed=is_closed
                 )
             else:
                 self._classroom = True, None


### PR DESCRIPTION
There is currently no way, only using scratchattach, to get the associated classroom of student accounts. It appears that there is no JSON site-api for this (or maybe I am just ignorant), however it is possible to work this out by viewing the `profile-details` `<p>` tag in the profile page HTML.

This PR implements a `site.user.User.classroom` getter method using the `@property` decorator and a cache attribute. As users can never change what class they are in, this cache value will never need to change, solving #382

<details>
The implementation uses bs4 to get the `<p>` tag, and uses `soup.find_all("a")` and a RegEx for each href to detect which anchor refers to the classroom. The only possible other instance of an anchor tag being used in there is for becoming a scratcher, but I am not sure.
</details>

Note: The returned classroom object will only contain a classroom id and a classroom title (and a boolean if it is ended?)

todo: 
- [x] There should be a check for if a class is ended.