### PR TITLE
feat: decode_session_id - to solve #395

### DIFF
--- a/scratchattach/utils/commons.py
+++ b/scratchattach/utils/commons.py
@@ -1,6 +1,8 @@
 """v2 ready: Common functions used by various internal modules"""
 from __future__ import annotations
 
+import string
+
 from typing import Optional, Final, Any, TypeVar, Callable, TYPE_CHECKING, Union
 from threading import Lock
 
@@ -8,6 +10,7 @@ from . import exceptions
 from .requests import Requests as requests
 
 from ..site import _base
+
 
 headers: Final = {
     "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
@@ -241,3 +244,14 @@ def get_class_sort_mode(mode: str) -> tuple[str, str]:
         descsort = "title"
 
     return ascsort, descsort
+
+
+def b62_decode(s: str):
+    chars = string.digits + string.ascii_uppercase + string.ascii_lowercase
+
+    ret = 0
+    for char in s:
+        ret = ret * 62 + chars.index(char)
+
+    return ret
+


### PR DESCRIPTION
### Decode session_id to reduce request count

Upon logging in, scratchattach fetches the xtoken separately from the session id, although the session id, when decoded, actually contains the xtoken and some other useful information.

This PR implements
- `utils.commons.b62_decode` - this decodes the base 62 timestamp (part 2 of the session id) into a unix timestamp
- `site.session.decode_session_id` - this decodes the session id into a dictionary containing various pieces of data (part 1 of the session id), and a datetime object generated from the base62 encoded timestamp
- `site.session.Session._process_session_id` - this sets attributes of the Session object using data which is collected from the session id. Note the use of the word _process_, which implies that no web requests are made. This method is automatically called upon `__init__` if a session id is provided

#### todo:
- [ ] simplify login functions which do not need to fetch the xtoken if the session id is already present
- [ ] testing