### PR TITLE
sb2 json fetch

### DIFF
--- a/scratchattach/site/browser_cookies.py
+++ b/scratchattach/site/browser_cookies.py
@@ -1,4 +1,5 @@
-from typing import Optional, assert_never, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
+from typing_extensions import assert_never
 from http.cookiejar import CookieJar
 from enum import Enum, auto
 browsercookie_err = None


### PR DESCRIPTION
# correctly decode sb2 (#415)
#### (project data that is not sent as project JSON, but as a sb2 (zip) file)

Sometimes, regarding 2.0 projects, the regular JSON endpoint for the project actually returns an sb2 file. This pull request
1. specifically catches the JSON decoder error when attempting to json-decode a zip file
2. decode the zip file and return `project.json` from the zip, if the previous error is caught

> [!note]
It is interesting to note that both sa.editor and project_json_capabilities use this same method for getting project JSON data by id, but it is wasteful to not cache the asset data included within the zip file. Since both of these submodules use this method, there is also probably not going to be code duplication.

I tested this like so:
```py
import warnings
from pprint import pprint

import scratchattach as sa
from local_test.payload import fa_qav

warnings.filterwarnings('ignore', category=sa.LoginDataWarning)

sess = sa.login(**fa_qav)


print(sess.connect_project("1023073403").raw_json())
print(sess.connect_project("918894112").raw_json())
```

todo:
- [X] test
- [ ] edit/add comments