### PR TITLE
replace parent imports with first party imports

### DIFF
--- a/scratchattach/cloud/_base.py
+++ b/scratchattach/cloud/_base.py
@@ -24,13 +24,13 @@ class SupportsClose(ABC):
 
 import websocket
 
-from ..site import session
-from ..eventhandlers import cloud_recorder
-from ..utils import exceptions
-from ..eventhandlers.cloud_requests import CloudRequests
-from ..eventhandlers.cloud_events import CloudEvents
-from ..eventhandlers.cloud_storage import CloudStorage
-from ..site import cloud_activity
+from scratchattach.site import session
+from scratchattach.eventhandlers import cloud_recorder
+from scratchattach.utils import exceptions
+from scratchattach.eventhandlers.cloud_requests import CloudRequests
+from scratchattach.eventhandlers.cloud_events import CloudEvents
+from scratchattach.eventhandlers.cloud_storage import CloudStorage
+from scratchattach.site import cloud_activity
 
 T = TypeVar("T")
 

--- a/scratchattach/cloud/cloud.py
+++ b/scratchattach/cloud/cloud.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from ._base import BaseCloud
 from typing import Type
-from ..utils.requests import requests
-from ..utils import exceptions, commons
-from ..site import cloud_activity
+from scratchattach.utils.requests import requests
+from scratchattach.utils import exceptions, commons
+from scratchattach.site import cloud_activity
 
 
 class ScratchCloud(BaseCloud):
@@ -88,7 +88,7 @@ class ScratchCloud(BaseCloud):
 
     def events(self, *, use_logs=False):
         if self._session is None or use_logs:
-            from ..eventhandlers.cloud_events import CloudLogEvents
+            from scratchattach.eventhandlers.cloud_events import CloudLogEvents
             return CloudLogEvents(self)
         else:
             return super().events()

--- a/scratchattach/editor/block.py
+++ b/scratchattach/editor/block.py
@@ -5,7 +5,7 @@ from typing import Optional, Iterable
 from typing_extensions import Self
 
 from . import base, sprite, mutation, field, inputs, commons, vlb, blockshape, prim, comment, build_defaulting
-from ..utils import exceptions
+from scratchattach.utils import exceptions
 
 
 class Block(base.SpriteSubComponent):

--- a/scratchattach/editor/blockshape.py
+++ b/scratchattach/editor/blockshape.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import Final
 
 from . import commons
-from ..utils.enums import _EnumWrapper
+from scratchattach.utils.enums import _EnumWrapper
 
 
 class _MutationDependent(commons.Singleton):

--- a/scratchattach/editor/commons.py
+++ b/scratchattach/editor/commons.py
@@ -8,7 +8,7 @@ import random
 import string
 from typing import Optional, Final, Any
 
-from ..utils import exceptions
+from scratchattach.utils import exceptions
 
 DIGITS: Final[tuple[str]] = tuple("0123456789")
 

--- a/scratchattach/editor/extension.py
+++ b/scratchattach/editor/extension.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from . import base
-from ..utils import enums
+from scratchattach.utils import enums
 
 
 @dataclass

--- a/scratchattach/editor/mutation.py
+++ b/scratchattach/editor/mutation.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Optional, TYPE_CHECKING, Iterable, Any
 
 from . import base, commons
-from ..utils import enums
+from scratchattach.utils import enums
 
 if TYPE_CHECKING:
     from . import block

--- a/scratchattach/editor/pallete.py
+++ b/scratchattach/editor/pallete.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from . import prim
-from ..utils.enums import _EnumWrapper
+from scratchattach.utils.enums import _EnumWrapper
 
 
 @dataclass

--- a/scratchattach/editor/prim.py
+++ b/scratchattach/editor/prim.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Optional, Callable, Final
 
 from . import base, sprite, vlb, commons, build_defaulting
-from ..utils import enums, exceptions
+from scratchattach.utils import enums, exceptions
 
 
 @dataclass

--- a/scratchattach/editor/project.py
+++ b/scratchattach/editor/project.py
@@ -8,9 +8,9 @@ from typing import Optional, Iterable, Generator, BinaryIO
 from zipfile import ZipFile
 
 from . import base, meta, extension, monitor, sprite, asset, vlb, twconfig, comment, commons
-from ..site import session
-from ..site.project import get_project
-from ..utils import exceptions
+from scratchattach.site import session
+from scratchattach.site.project import get_project
+from scratchattach.utils import exceptions
 
 
 class Project(base.JSONExtractable):

--- a/scratchattach/editor/vlb.py
+++ b/scratchattach/editor/vlb.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Optional, Literal
 
 from . import base, sprite, build_defaulting
-from ..utils import exceptions
+from scratchattach.utils import exceptions
 
 
 class Variable(base.NamedIDComponent):

--- a/scratchattach/eventhandlers/_base.py
+++ b/scratchattach/eventhandlers/_base.py
@@ -5,8 +5,8 @@ from collections import defaultdict
 from threading import Thread
 from collections.abc import Callable
 import traceback
-from ..utils.requests import requests
-from ..utils import exceptions
+from scratchattach.utils.requests import requests
+from scratchattach.utils import exceptions
 
 class BaseEventHandler(ABC):
     _events: defaultdict[str, list[Callable]]

--- a/scratchattach/eventhandlers/cloud_events.py
+++ b/scratchattach/eventhandlers/cloud_events.py
@@ -1,9 +1,9 @@
 """CloudEvents class"""
 from __future__ import annotations
 
-from ..cloud import _base
+from scratchattach.cloud import _base
 from ._base import BaseEventHandler
-from ..site import cloud_activity
+from scratchattach.site import cloud_activity
 import time
 import json
 from collections.abc import Iterator

--- a/scratchattach/eventhandlers/cloud_requests.py
+++ b/scratchattach/eventhandlers/cloud_requests.py
@@ -2,13 +2,13 @@
 from __future__ import annotations
 
 from .cloud_events import CloudEvents
-from ..site import project
+from scratchattach.site import project
 from threading import Thread, Event, current_thread
 import time
 import random
 import traceback
-from ..utils.encoder import Encoding
-from ..utils import exceptions
+from scratchattach.utils.encoder import Encoding
+from scratchattach.utils import exceptions
 
 class Request:
 

--- a/scratchattach/eventhandlers/cloud_server.py
+++ b/scratchattach/eventhandlers/cloud_server.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from SimpleWebSocketServer import SimpleWebSocketServer, WebSocket
 from threading import Thread
-from ..utils import exceptions
+from scratchattach.utils import exceptions
 import json
 import time
-from ..site import cloud_activity
-from ..site.user import User
+from scratchattach.site import cloud_activity
+from scratchattach.site.user import User
 from ._base import BaseEventHandler
 
 class TwCloudSocket(WebSocket):

--- a/scratchattach/eventhandlers/message_events.py
+++ b/scratchattach/eventhandlers/message_events.py
@@ -1,7 +1,7 @@
 """MessageEvents class"""
 from __future__ import annotations
 
-from ..site import user
+from scratchattach.site import user
 from ._base import BaseEventHandler
 import time
 

--- a/scratchattach/other/other_apis.py
+++ b/scratchattach/other/other_apis.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 
-from ..utils import commons
-from ..utils.enums import Languages, Language, TTSVoices, TTSVoice
-from ..utils.exceptions import BadRequest, InvalidLanguage, InvalidTTSGender
-from ..utils.requests import requests
+from scratchattach.utils import commons
+from scratchattach.utils.enums import Languages, Language, TTSVoices, TTSVoice
+from scratchattach.utils.exceptions import BadRequest, InvalidLanguage, InvalidTTSGender
+from scratchattach.utils.requests import requests
 from typing import Optional
 
 

--- a/scratchattach/other/project_json_capabilities.py
+++ b/scratchattach/other/project_json_capabilities.py
@@ -10,9 +10,9 @@ import random
 import string
 import zipfile
 from abc import ABC, abstractmethod
-from ..utils import exceptions
-from ..utils.commons import empty_project_json
-from ..utils.requests import requests
+from scratchattach.utils import exceptions
+from scratchattach.utils.commons import empty_project_json
+from scratchattach.utils.requests import requests
 # noinspection PyPep8Naming
 def load_components(json_data: list, ComponentClass: type, target_list: list):
     for element in json_data:

--- a/scratchattach/site/_base.py
+++ b/scratchattach/site/_base.py
@@ -4,8 +4,8 @@ from abc import ABC, abstractmethod
 from typing import TypeVar, Optional
 
 import requests
+from scratchattach.utils import exceptions, commons
 from . import session
-from ..utils import exceptions, commons
 
 C = TypeVar("C", bound="BaseSiteComponent")
 class BaseSiteComponent(ABC):

--- a/scratchattach/site/activity.py
+++ b/scratchattach/site/activity.py
@@ -5,7 +5,7 @@ from bs4 import PageElement
 
 from . import user, project, studio
 from ._base import BaseSiteComponent
-from ..utils import exceptions
+from scratchattach.utils import exceptions
 
 
 class Activity(BaseSiteComponent):

--- a/scratchattach/site/alert.py
+++ b/scratchattach/site/alert.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 from typing_extensions import Self
 
 from . import user, project, studio, comment, session
-from ..utils import enums
+from scratchattach.utils import enums
 
 if TYPE_CHECKING:
     ...

--- a/scratchattach/site/backpack_asset.py
+++ b/scratchattach/site/backpack_asset.py
@@ -5,8 +5,8 @@ import time
 import logging
 
 from ._base import BaseSiteComponent
-from ..utils import exceptions
-from ..utils.requests import requests
+from scratchattach.utils import exceptions
+from scratchattach.utils.requests import requests
 
 
 

--- a/scratchattach/site/classroom.py
+++ b/scratchattach/site/classroom.py
@@ -7,13 +7,13 @@ from typing import Optional, TYPE_CHECKING, Any
 import bs4
 
 if TYPE_CHECKING:
-    from ..site.session import Session
+    from scratchattach.site.session import Session
 
-from ..utils.commons import requests
+from scratchattach.utils.commons import requests
 from . import user, activity
 from ._base import BaseSiteComponent
-from ..utils import exceptions, commons
-from ..utils.commons import headers
+from scratchattach.utils import exceptions, commons
+from scratchattach.utils.commons import headers
 
 from bs4 import BeautifulSoup
 

--- a/scratchattach/site/cloud_activity.py
+++ b/scratchattach/site/cloud_activity.py
@@ -91,8 +91,8 @@ class CloudActivity(BaseSiteComponent):
         """
         if self.username is None:
             return None
-        from ..site import user
-        from ..utils import exceptions
+        from scratchattach.site import user
+        from scratchattach.utils import exceptions
         return self._make_linked_object("username", self.username, user.User, exceptions.UserNotFound)
 
     def project(self):
@@ -101,7 +101,7 @@ class CloudActivity(BaseSiteComponent):
         """
         if self.cloud is None:
             return None
-        from ..site import project
-        from ..utils import exceptions
+        from scratchattach.site import project
+        from scratchattach.utils import exceptions
         return self._make_linked_object("id", self.cloud.project_id, project.Project, exceptions.ProjectNotFound)
 

--- a/scratchattach/site/comment.py
+++ b/scratchattach/site/comment.py
@@ -7,7 +7,7 @@ from enum import Enum, auto
 
 from . import user, project, studio
 from ._base import BaseSiteComponent
-from ..utils import exceptions
+from scratchattach.utils import exceptions
 
 class CommentSource(Enum):
     PROJECT = auto()

--- a/scratchattach/site/forum.py
+++ b/scratchattach/site/forum.py
@@ -10,10 +10,10 @@ from bs4 import BeautifulSoup, Tag
 
 from . import user
 from . import session as module_session
-from ..utils.commons import headers
-from ..utils import exceptions, commons
+from scratchattach.utils.commons import headers
+from scratchattach.utils import exceptions, commons
 from ._base import BaseSiteComponent
-from ..utils.requests import requests
+from scratchattach.utils.requests import requests
 
 @dataclass
 class ForumTopic(BaseSiteComponent):

--- a/scratchattach/site/project.py
+++ b/scratchattach/site/project.py
@@ -10,12 +10,12 @@ from io import BytesIO
 
 from typing import Any
 from . import user, comment, studio
-from ..utils import exceptions
-from ..utils import commons
-from ..utils.commons import empty_project_json, headers
+from scratchattach.utils import exceptions
+from scratchattach.utils import commons
+from scratchattach.utils.commons import empty_project_json, headers
 from ._base import BaseSiteComponent
-from ..other.project_json_capabilities import ProjectBody
-from ..utils.requests import requests
+from scratchattach.other.project_json_capabilities import ProjectBody
+from scratchattach.utils.requests import requests
 
 CREATE_PROJECT_USES: list[float] = []
 

--- a/scratchattach/site/session.py
+++ b/scratchattach/site/session.py
@@ -20,7 +20,7 @@ Type = type
 
 if TYPE_CHECKING:
     from _typeshed import FileDescriptorOrPath, SupportsRead
-    from ..cloud._base import BaseCloud
+    from scratchattach.cloud._base import BaseCloud
     T = TypeVar("T", bound=BaseCloud)
 else:
     T = TypeVar("T")
@@ -31,13 +31,13 @@ from typing_extensions import deprecated
 from . import activity, classroom, forum, studio, user, project, backpack_asset, alert
 # noinspection PyProtectedMember
 from ._base import BaseSiteComponent
-from ..cloud import cloud, _base
-from ..eventhandlers import message_events, filterbot
-from ..other import project_json_capabilities
-from ..utils import commons
-from ..utils import exceptions
-from ..utils.commons import headers, empty_project_json, webscrape_count, get_class_sort_mode
-from ..utils.requests import requests
+from scratchattach.cloud import cloud, _base
+from scratchattach.eventhandlers import message_events, filterbot
+from scratchattach.other import project_json_capabilities
+from scratchattach.utils import commons
+from scratchattach.utils import exceptions
+from scratchattach.utils.commons import headers, empty_project_json, webscrape_count, get_class_sort_mode
+from scratchattach.utils.requests import requests
 from .browser_cookies import Browser, ANY, cookies_from_browser
 
 ratelimit_cache: dict[str, list[float]] = {}

--- a/scratchattach/site/studio.py
+++ b/scratchattach/site/studio.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 import json
 import random
 from . import user, comment, project, activity
-from ..utils import exceptions, commons
-from ..utils.commons import api_iterative, headers
+from scratchattach.utils import exceptions, commons
+from scratchattach.utils.commons import api_iterative, headers
 from ._base import BaseSiteComponent
 
-from ..utils.requests import requests
+from scratchattach.utils.requests import requests
 
 
 class Studio(BaseSiteComponent):

--- a/scratchattach/site/user.py
+++ b/scratchattach/site/user.py
@@ -10,12 +10,12 @@ from datetime import datetime, timezone
 from bs4 import BeautifulSoup, Tag
 
 from ._base import BaseSiteComponent
-from ..eventhandlers import message_events
+from scratchattach.eventhandlers import message_events
 
-from ..utils import commons
-from ..utils import exceptions
-from ..utils.commons import headers
-from ..utils.requests import requests
+from scratchattach.utils import commons
+from scratchattach.utils import exceptions
+from scratchattach.utils.commons import headers
+from scratchattach.utils.requests import requests
 
 from . import project
 from . import studio

--- a/scratchattach/utils/commons.py
+++ b/scratchattach/utils/commons.py
@@ -9,7 +9,7 @@ from threading import Lock
 from . import exceptions
 from .requests import requests
 
-from ..site import _base
+from scratchattach.site import _base
 
 
 headers: Final = {
@@ -133,7 +133,7 @@ def _get_object(identificator_name, identificator, __class: type[C], NotFoundExc
     # Internal function: Generalization of the process ran by get_user, get_studio etc.
     # Builds an object of class that is inheriting from BaseSiteComponent
     # # Class must inherit from BaseSiteComponent
-    from ..site import project
+    from scratchattach.site import project
     try:
         use_class: type = __class
         if __class is project.PartialProject:


### PR DESCRIPTION
Absolute first party imports are encouraged to be used instead of relative parent imports.