### PR TITLE
merge user.scratchteam and user.is_new_scratcher() to user.rank()

### DIFF
--- a/scratchattach/site/user.py
+++ b/scratchattach/site/user.py
@@ -885,7 +885,7 @@ class User(BaseSiteComponent):
         v = Verificator(self, verification_project_id)
         return v
 
-    def rank(self):
+    def rank(self) -> Rank:
         """
         Finds the rank of the user.
         Returns a member of the Rank enum: either Rank.NEW_SCRATCHER, Rank.SCRATCHER, or Rank.SCRATCH_TEAM.


### PR DESCRIPTION
Currently the function looks like this:
```python
    def rank(self):
        """
        Finds the rank of the user.
        May replace user.scratchteam and user.is_mew_scratcher in the future.
        """

        ns = self.is_new_scratcher()
        if ns == True:
            return 0
            #is new scratcher#
        elif ns == False:
            ns = self.scratchteam
            if ns == False:
                return 1
                #is scratcher#
            else:
                return 2
                #is scratch team member#
```
Supposedly, it should work by calling to the other functions within the user class and determining the rank of a user via if-else statements. 
However, I have **not** tested this, and I don't know if it works. 

See this issue for more info: https://github.com/TimMcCool/scratchattach/issues/447