### PR TITLE
Add pip install websockets to workflow, hopefully fixing the failed tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,6 +31,7 @@ jobs:
           pip install . # install scratchattach from fs and dependencies
           pip install pytest
           pip install cryptography
+          pip install websockets
 
       - name: Test with pytest
         env:


### PR DESCRIPTION
<!-- Thanks for contributing to scratchattach! -->

There isn't any issues for this, just noticed test were failing due to missing websockets extension

### Changes
Added pip install websockets to PR test workflow
### Tests
I ran the workflow.