### PR TITLE
feat: memberships

### DIFF
--- a/scratchattach/site/typed_dicts.py
+++ b/scratchattach/site/typed_dicts.py
@@ -78,6 +78,8 @@ class UserProfileDict(TypedDict):
     bio: str
     country: str
     images: dict[str, str]
+    membership_label: NotRequired[int]
+    membership_avatar_badge: NotRequired[int]
 
 class UserDict(TypedDict):
     id: NotRequired[int]

--- a/tests/test_memberships.py
+++ b/tests/test_memberships.py
@@ -1,4 +1,33 @@
 import scratchattach as sa
+import warnings
 
+warnings.filterwarnings("ignore", category=sa.UserAuthenticationWarning)
 def test_memberships():
-    ...
+    # unfortunately we don't have amazingly robust test-cases here.
+    u1 = sa.get_user("-KittyMax-")
+    assert u1.is_member
+    assert not u1.has_ears
+    assert u1.has_badge()
+
+    u2 = sa.get_user("ceebee")
+    assert u2.is_member
+    assert u2.has_ears
+    assert u2.has_badge()
+
+    u3 = sa.get_user("scratchattachv2")
+    assert not u3.is_member
+    assert not u3.has_ears
+    assert not u3.has_badge()
+
+    u4 = sa.get_user("peekir")
+    assert u4.is_member
+    assert u4.has_ears
+    assert u4.has_badge()
+
+    u5 = sa.get_user("StardreamT2")
+    assert u5.is_member
+    assert u5.has_ears
+    assert not u5.has_badge()
+
+if __name__ == "__main__":
+    test_memberships()


### PR DESCRIPTION
implements membership detections.

Solves issues #546 & #551

### Changes

This

- adds detection for ears, membership and badge
- removes the use of sys.path

### Tests

`tests/test_membership.py`

> [!WARNING]
> The tests are somewhat unrobust because they rely on certain scratch users not changing their configuration for their scratch membership, and assumes they are on a lifetime membership.
> The tests may also fail if scratch changes the way that the badge is displayed. However, since it is literally an image with no class/id, there is likely not a more robust way to look for it.
