### PR TITLE
perf: comment_by_id

### DIFF
--- a/tests/test_comment_by_id.py
+++ b/tests/test_comment_by_id.py
@@ -1,0 +1,10 @@
+import scratchattach as sa
+
+
+def test_comment_by_id():
+    usr = sa.get_user("griffpatch")
+    comment = usr.comment_by_id(398143091)
+    print(comment)
+
+if __name__ == "__main__":
+    test_comment_by_id()


### PR DESCRIPTION
see issue #553

### Changes

edits the `User.comment_by_id` logic to use an exponential-binary search to get comments faster.

> [!CAUTION]
> This **does not work** right now! This is because there is a great number of edge cases that must be considered.
> 1. consider empty pages (these are not necessarily the last)
> 2. consider error 404 pages (these **are** necessarily beyond the end
> 3. **consider the fact that comments can move between pages (but only forward) - this is noticeable with griffpatch's page**
> 4. make sure the logic works for comments at the very start and end of pages
> 5. you will want to transfer these changes to studios and projects...right?
>
> and then the behaviors that correspond to them:
> 1. don't immediately exit, and check forwards/backwards linearly until a comparison can be made. when both sides are reached, evaluate whether the comemnt_id is in this range; if so, comment not found
> 2. check backwards linearly? it tends to be page 67 for some reason but idk why
> 3. This one is the hard one
> 4. use `<`, `>`, `<=`, and `>=` appropriately and test them well
> 5. reimplement twice or create a layer of abstraction that can be used (interface?)


### Tests

`test_comment_by_id.py`. In production, we will need to test this on comments on scratchattachV2