### PR TITLE
feat: add `is_followed_by_me` to fix #571

### DIFF
--- a/scratchattach/site/user.py
+++ b/scratchattach/site/user.py
@@ -494,6 +494,29 @@ class User(BaseSiteComponent[typed_dicts.UserDict]):
                 return followed
         return followed
 
+    def is_followed_by_me(self):
+        """
+        You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_user`
+        
+        Returns:
+            boolean: Whether the user is followed by the user currently logged in.
+        """
+        self._assert_permission()
+        with requests.no_error_handling():
+            resp = requests.get(
+                f"https://scratch.mit.edu/users/{self.username}/",
+                headers=self._headers,
+                cookies=self._cookies,
+            )
+        soup = BeautifulSoup(resp.text, "html.parser")
+        follow_btn = soup.select_one("div.follow-button")
+        if not follow_btn:
+            print("Warning: follow button not found in page.")
+            return False # defualt to not followed
+        data_control = follow_btn.get("data-control")
+        return data_control == 'unfollow' # True if unfollow, False if not
+        
+
     def project_count(self):
         with requests.no_error_handling():
             text = requests.get(

--- a/scratchattach/site/user.py
+++ b/scratchattach/site/user.py
@@ -501,7 +501,7 @@ class User(BaseSiteComponent[typed_dicts.UserDict]):
         Returns:
             boolean: Whether the user is followed by the user currently logged in.
         """
-        self._assert_permission()
+        self._assert_auth()
         with requests.no_error_handling():
             resp = requests.get(
                 f"https://scratch.mit.edu/users/{self.username}/",

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -6,7 +6,7 @@ from util import session, credentials_available
 def test_user():
     if not credentials_available():
         warnings.warn(
-            "Skipped test_studio because there were no credentials available."
+            "Skipped test_user because there were no credentials available."
         )
         return
     sess = session()

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -106,6 +106,11 @@ def test_user():
     assert status_data["status"] == "Sample status"
     assert status_data["color"] == "#855cd6"
 
+    uukelele = sess.connect_user("uukelele") # could use anyone ScratchAttachV2 is following right now but i think its cool that its following my account - uukelele, 2026
+    assert uukelele.is_followed_by_me()
+    # and someone he is not following
+    assert not griffpatch.is_followed_by_me()
+
 
 if __name__ == "__main__":
     test_user()


### PR DESCRIPTION
<!-- Thanks for contributing to scratchattach! -->

Solves issue #571
<!-- 
Give the issue that this solves from:
https://github.com/TimMcCool/scratchattach/issues
-->

### Changes
<!-- 
Give details about your PR,
e.g. names of functions you added, and/or a brief overview of how it internally works
-->
added `is_followed_by_me` which uses the follow button.

### Tests

<!--
Please test your changes using python 3.12+ before submitting a PR.
If you can, provide an automated test in the tests/ directory.

You can add any other notes here.
-->

works and is ready to merge.

one thing I noticed though:

for users with small amount e.g. <20 followers, `is_followed_by` is actually faster, in my case (19 followers) 0.19s vs 0.94s.

but for those with more followers e.g. 100, `is_followed_by` is slower, in my case (131 followers) 1.58s vs 0.54s