### PR TITLE
fix: use .text to handle empty project titles in user.loves() (#581)

### DIFF
--- a/scratchattach/site/user.py
+++ b/scratchattach/site/user.py
@@ -654,8 +654,8 @@ class User(BaseSiteComponent[typed_dicts.UserDict]):
                     project_id = commons.webscrape_count(
                         first_anchor.attrs["href"], "/projects/", "/"
                     )
-                    title = second_anchor.contents[0]
-                    author = third_anchor.contents[0]
+                    title = second_anchor.text
+                    author = third_anchor.text
 
                     # Instantiating a project with the properties that we know
                     # This may cause issues (see below)

--- a/scratchattach/site/user.py
+++ b/scratchattach/site/user.py
@@ -655,7 +655,7 @@ class User(BaseSiteComponent[typed_dicts.UserDict]):
                         first_anchor.attrs["href"], "/projects/", "/"
                     )
                     title = second_anchor.text
-                    author = third_anchor.text
+                    author = third_anchor.contents[0]
 
                     # Instantiating a project with the properties that we know
                     # This may cause issues (see below)


### PR DESCRIPTION
Fixes #581

The issue happens because .contents[0] throws an IndexError when a project has no title. Switching to .text returns an empty string instead, which handles that case cleanly.