### PR TITLE
feat: Temporarily negate `ProjectAuthenticationWarning` when using `Project.is_shared()`

### DIFF
--- a/scratchattach/site/project.py
+++ b/scratchattach/site/project.py
@@ -9,7 +9,7 @@ import time
 import warnings
 import zipfile
 from io import BytesIO
-from typing import Callable, Union
+from typing import Callable, Union, cast
 
 from dataclasses import dataclass, field
 from typing import Any, Optional
@@ -185,13 +185,11 @@ class PartialProject(BaseSiteComponent):
         Returns:
             boolean: Returns whether the project is currently shared
         """
-        try:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", category=exceptions.ProjectAuthenticationWarning)
-                p = get_project(self.id)
-                return isinstance(p, Project)
-        except exceptions.ProjectNotFound:
+        response = requests.get(f"https://api.scratch.mit.edu/projects/{self.id}")
+        if response.status_code == 404:
             return False
+        response_json = cast(ProjectDict, response.json())
+        return response_json["is_published"]
 
     def raw_json_or_empty(self) -> dict[str, Any]:
         return empty_project_json

--- a/scratchattach/site/project.py
+++ b/scratchattach/site/project.py
@@ -193,7 +193,7 @@ class PartialProject(BaseSiteComponent):
         except exceptions.ProjectNotFound:
             return False
 
-    def raw_json_or_empty(self) -> dict[str, Any]
+    def raw_json_or_empty(self) -> dict[str, Any]:
         return empty_project_json
 
     def create_remix(self, *, title=None, project_json=None) -> Project:  # not working

--- a/scratchattach/site/project.py
+++ b/scratchattach/site/project.py
@@ -186,12 +186,14 @@ class PartialProject(BaseSiteComponent):
             boolean: Returns whether the project is currently shared
         """
         try:
-            p = get_project(self.id)
-            return isinstance(p, Project)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=exceptions.ProjectAuthenticationWarning)
+                p = get_project(self.id)
+                return isinstance(p, Project)
         except exceptions.ProjectNotFound:
             return False
 
-    def raw_json_or_empty(self) -> dict[str, Any]:
+    def raw_json_or_empty(self) -> dict[str, Any]
         return empty_project_json
 
     def create_remix(self, *, title=None, project_json=None) -> Project:  # not working


### PR DESCRIPTION
<!-- Thanks for contributing to scratchattach! -->

Solves issue #592 

### Changes
- Negated `Project.get_project`'s `ProjectAuthenticationWarning` using `warnings.catch_warnings()`

### Tests
Tested in CPython 3.12.1 REPL
```py
Python 3.12.1 (main, Mar 11 2026, 12:17:56) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
Ctrl click to launch VS Code Native REPL
>>> import scratchattach
>>> print(scratchattach.Project(id=103).is_shared())
False
>>> print(scratchattach.Project(id=104).is_shared())
True
>>> print(scratchattach.get_project(103))
/workspaces/scratchattach/src/scratchattach/scratchattach/site/project.py:828: ProjectAuthenticationWarning: For methods that require authentication, use session.connect_project instead of get_project.
If you want to remove this warning, use `warnings.filterwarnings('ignore', category=scratchattach.ProjectAuthenticationWarning)`.
To ignore all warnings of the type GetAuthenticationWarning, which includes this warning, use `warnings.filterwarnings('ignore', category=scratchattach.GetAuthenticationWarning)`.
  warnings.warn(
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/workspaces/scratchattach/src/scratchattach/scratchattach/site/project.py", line 836, in get_project
    return commons._get_object("id", project_id, Project, exceptions.ProjectNotFound)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/scratchattach/src/scratchattach/scratchattach/utils/commons.py", line 163, in _get_object
    raise e
  File "/workspaces/scratchattach/src/scratchattach/scratchattach/utils/commons.py", line 157, in _get_object
    raise NotFoundException
scratchattach.utils.exceptions.ProjectNotFound
>>> print(scratchattach.Project(id=104).is_shared())
True
>>> print(scratchattach.get_project(104))
/workspaces/scratchattach/src/scratchattach/scratchattach/site/project.py:828: ProjectAuthenticationWarning: For methods that require authentication, use session.connect_project instead of get_project.
If you want to remove this warning, use `warnings.filterwarnings('ignore', category=scratchattach.ProjectAuthenticationWarning)`.
To ignore all warnings of the type GetAuthenticationWarning, which includes this warning, use `warnings.filterwarnings('ignore', category=scratchattach.GetAuthenticationWarning)`.
  warnings.warn(
-P 104 (Weekend)
>>> exit()
```
