### PR TITLE
chore: more robust membership tests

### DIFF
--- a/tests/test_memberships.py
+++ b/tests/test_memberships.py
@@ -4,10 +4,8 @@ import warnings
 warnings.filterwarnings("ignore", category=sa.UserAuthenticationWarning)
 
 
-def test_memberships():
-    # unfortunately we don't have amazingly robust test-cases here.
-    
-    # these are subject to change, we need to find long term members for this
+def test_memberships():    
+    # NOTE: these are subject to change
     member_users = [
         sa.get_user("-KittyMax-"),
         sa.get_user("scratchteam"),

--- a/tests/test_memberships.py
+++ b/tests/test_memberships.py
@@ -1,5 +1,4 @@
 import scratchattach as sa
-from scratchattach import get_user, is_member, has_ears, has_badge
 import warnings
 
 warnings.filterwarnings("ignore", category=sa.UserAuthenticationWarning)
@@ -10,16 +9,16 @@ def test_memberships():
     
     # these are subject to change, we need to find long term members for this
     member_users = [
-        get_user("-KittyMax-"),
-        get_user("scratchteam"),
-        get_user("peekir"),
-        get_user("StardreamT2"),
+        sa.get_user("-KittyMax-"),
+        sa.get_user("scratchteam"),
+        sa.get_user("peekir"),
+        sa.get_user("StardreamT2"),
     ]
     nomember_users = [
-        get_user("scratchattachv2"),
-        get_user("GoatyJules"),
-        get_user("SkittlesTheBunny"),
-        get_user("Boss_1s") # not sure if it works since im banned
+        sa.get_user("scratchattachv2"),
+        sa.get_user("GoatyJules"),
+        sa.get_user("SkittlesTheBunny"),
+        sa.get_user("Boss_1s") # not sure if it works since im banned
     ]
 
     assert all(getattr(user, "is_member", False) for user in member_users)

--- a/tests/test_memberships.py
+++ b/tests/test_memberships.py
@@ -1,4 +1,5 @@
 import scratchattach as sa
+from scratchattach import get_user, is_member, has_ears, has_badge
 import warnings
 
 warnings.filterwarnings("ignore", category=sa.UserAuthenticationWarning)
@@ -6,30 +7,56 @@ warnings.filterwarnings("ignore", category=sa.UserAuthenticationWarning)
 
 def test_memberships():
     # unfortunately we don't have amazingly robust test-cases here.
-    u1 = sa.get_user("-KittyMax-")
-    assert u1.is_member  # NOTE: This may be wrong! I think it might be supposed to be False here...
-    assert not u1.has_ears
-    assert u1.has_badge()
+    
+    # these are subject to change, we need to find long term members for this
+    member_users = [
+        get_user("-KittyMax-"),
+        get_user("scratchteam"),
+        get_user("peekir"),
+        get_user("StardreamT2"),
+    ]
+    nomember_users = [
+        get_user("scratchattachv2"),
+        get_user("GoatyJules"),
+        get_user("SkittlesTheBunny"),
+        get_user("Boss_1s") # not sure if it works since im banned
+    ]
 
-    u2 = sa.get_user("scratchteam")
-    assert u2.is_member
-    assert u2.has_ears
-    assert u2.has_badge()
+    assert all(getattr(user, "is_member", False) for user in member_users)
+    assert all(not getattr(user, "is_member", True) for user in nomember_users)
+    
+    assert any(getattr(user, "has_ears", False) for user in member_users)
+    assert all(not getattr(user, "has_ears", True) for user in nomember_users)
 
-    u3 = sa.get_user("scratchattachv2")
-    assert not u3.is_member
-    assert not u3.has_ears
-    assert not u3.has_badge()
+    assert any(user.has_badge() for user in member_users)
+    assert all(not user.has_badge() for user in nomember_users)
 
-    u4 = sa.get_user("peekir")
-    assert u4.is_member
-    assert u4.has_ears
-    assert u4.has_badge()
+    # keeping old test in case
 
-    u5 = sa.get_user("StardreamT2")
-    assert u5.is_member
-    assert u5.has_ears
-    assert not u5.has_badge()
+    #u1 = sa.get_user("-KittyMax-")
+    #assert u1.is_member  # NOTE: This may be wrong! I think it might be supposed to be False here...
+    #assert not u1.has_ears
+    #assert u1.has_badge()
+
+    #u2 = sa.get_user("scratchteam")
+    #assert u2.is_member
+    #assert u2.has_ears
+    #assert u2.has_badge()
+
+    #u3 = sa.get_user("scratchattachv2")
+    #assert not u3.is_member
+    #assert not u3.has_ears
+    #assert not u3.has_badge()
+
+    #u4 = sa.get_user("peekir")
+    #assert u4.is_member
+    #assert u4.has_ears
+    #assert u4.has_badge()
+
+    #u5 = sa.get_user("StardreamT2")
+    #assert u5.is_member
+    #assert u5.has_ears
+    #assert not u5.has_badge()
 
 
 if __name__ == "__main__":

--- a/tests/test_memberships.py
+++ b/tests/test_memberships.py
@@ -19,11 +19,11 @@ def test_memberships():
         sa.get_user("Boss_1s")
     ]
 
-    assert all(getattr(user, "is_member", False) for user in member_users)
-    assert all(not getattr(user, "is_member", True) for user in nomember_users)
+    assert all(user.is_member for user in member_users)
+    assert all(not user.is_member for user in nomember_users)
     
-    assert any(getattr(user, "has_ears", False) for user in member_users)
-    assert all(not getattr(user, "has_ears", True) for user in nomember_users)
+    assert any(user.has_ears for user in member_users)
+    assert all(not user.has_ears for user in nomember_users)
 
     assert any(user.has_badge() for user in member_users)
     assert all(not user.has_badge() for user in nomember_users)

--- a/tests/test_memberships.py
+++ b/tests/test_memberships.py
@@ -18,7 +18,7 @@ def test_memberships():
         sa.get_user("scratchattachv2"),
         sa.get_user("GoatyJules"),
         sa.get_user("SkittlesTheBunny"),
-        sa.get_user("Boss_1s") # not sure if it works since im banned
+        sa.get_user("Boss_1s")
     ]
 
     assert all(getattr(user, "is_member", False) for user in member_users)
@@ -29,33 +29,6 @@ def test_memberships():
 
     assert any(user.has_badge() for user in member_users)
     assert all(not user.has_badge() for user in nomember_users)
-
-    # keeping old test in case
-
-    #u1 = sa.get_user("-KittyMax-")
-    #assert u1.is_member  # NOTE: This may be wrong! I think it might be supposed to be False here...
-    #assert not u1.has_ears
-    #assert u1.has_badge()
-
-    #u2 = sa.get_user("scratchteam")
-    #assert u2.is_member
-    #assert u2.has_ears
-    #assert u2.has_badge()
-
-    #u3 = sa.get_user("scratchattachv2")
-    #assert not u3.is_member
-    #assert not u3.has_ears
-    #assert not u3.has_badge()
-
-    #u4 = sa.get_user("peekir")
-    #assert u4.is_member
-    #assert u4.has_ears
-    #assert u4.has_badge()
-
-    #u5 = sa.get_user("StardreamT2")
-    #assert u5.is_member
-    #assert u5.has_ears
-    #assert not u5.has_badge()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thanks for contributing to scratchattach! -->

Solves issue #636 

### Changes
- Added lists for members and non-members, allowing check for both
- Refactored membership test using `any(getattr(...))` and `all(getattr(...))`

Commented out old test in case, if this passes i'll remove it

### Tests
[`tests/test_memberships.py`](https://github.com/TimMcCool/scratchattach/blob/main/tests/test_memberships.py)
