### PR TITLE
make language field of session optional

### DIFF
--- a/scratchattach/site/session.py
+++ b/scratchattach/site/session.py
@@ -88,7 +88,7 @@ class Session(BaseSiteComponent):
     is_teacher: bool = field(repr=False, default=None)
 
     time_created: datetime.datetime = None
-    language: str = field(repr=False, default="en")
+    language: Optional[str] = field(repr=False, default="en")
 
     def __str__(self) -> str:
         return f"<Login for {self.username!r}>"
@@ -161,7 +161,7 @@ class Session(BaseSiteComponent):
 
         # not saving the login ip because it is a security issue, and is not very helpful
 
-        self.language = data["_language"]
+        self.language = data.get("_language")
         # self._cookies["scratchlanguage"] = self.language
 
     def connect_linked_user(self) -> user.User:


### PR DESCRIPTION
<!-- Thanks for contributing to scratchattach! -->

Solves issues with logging in with language-less session ids
<!-- 
Give the issue that this solves from:
https://github.com/TimMcCool/scratchattach/issues
-->

### Changes
<!-- 
Give details about your PR,
e.g. names of functions you added, and/or a brief overview of how it internally works
-->
Made language field of session optional

### Tests

<!--
Please test your changes using python 3.12+ before submitting a PR.
If you can, provide an automated test in the tests/ directory.

You can add any other notes here.
-->
