### PR TITLE
fix: ignore non-JSON project share responses

### DIFF
--- a/scratchattach/site/project.py
+++ b/scratchattach/site/project.py
@@ -619,11 +619,12 @@ class Project(PartialProject):
         Shares the project. You can only use this function if this object was created using :meth:`scratchattach.session.Session.connect_project`
         """
         self._assert_permission()
-        requests.put(
-            f"https://api.scratch.mit.edu/proxy/projects/{self.id}/share/",
-            headers=self._json_headers,
-            cookies=self._cookies,
-        )
+        with requests.no_error_handling():
+            requests.put(
+                f"https://api.scratch.mit.edu/proxy/projects/{self.id}/share/",
+                headers=self._json_headers,
+                cookies=self._cookies,
+            )
 
     def unshare(self):
         """

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -5,42 +5,29 @@ from datetime import datetime
 from scratchattach.site.project import Project
 
 
-class FakeSession:
-    username = "ScratchAttachV2"
-
-    def get_headers(self):
-        return {"x-token": "token"}
-
-    def get_cookies(self):
-        return {"scratchsessionsid": "session"}
-
-
 def test_project_share_disables_response_json_error_handling(monkeypatch):
-    project = Project(id=123, author_name="ScratchAttachV2", _session=FakeSession())
-    calls = []
+    # Regression for #609: a shared response with a non-JSON body must not trip
+    # the response checker, so share() should run the PUT with error_handling
+    # disabled and restore it afterwards.
+    class FakeSession:
+        username = "ScratchAttachV2"
+
+        def get_headers(self):
+            return {"x-token": "token"}
+
+        def get_cookies(self):
+            return {"scratchsessionsid": "session"}
+
+    flag_during = []
 
     def fake_put(*args, **kwargs):
-        calls.append((args, kwargs, sa.utils.requests.requests.error_handling))
+        flag_during.append(sa.utils.requests.requests.error_handling)
 
     monkeypatch.setattr(sa.utils.requests.requests, "put", fake_put)
+    Project(id=123, author_name="ScratchAttachV2", _session=FakeSession()).share()
 
-    project.share()
-
-    assert calls == [
-        (
-            ("https://api.scratch.mit.edu/proxy/projects/123/share/",),
-            {
-                "headers": {
-                    "x-token": "token",
-                    "accept": "application/json",
-                    "Content-Type": "application/json",
-                },
-                "cookies": {"scratchsessionsid": "session"},
-            },
-            False,
-        )
-    ]
-    assert sa.utils.requests.requests.error_handling is True
+    assert flag_during == [False]  # disabled during the PUT
+    assert sa.utils.requests.requests.error_handling is True  # restored after
 
 
 def test_project():

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2,6 +2,45 @@ import warnings
 from util import session, credentials_available, allow_before
 import scratchattach as sa
 from datetime import datetime
+from scratchattach.site.project import Project
+
+
+class FakeSession:
+    username = "ScratchAttachV2"
+
+    def get_headers(self):
+        return {"x-token": "token"}
+
+    def get_cookies(self):
+        return {"scratchsessionsid": "session"}
+
+
+def test_project_share_disables_response_json_error_handling(monkeypatch):
+    project = Project(id=123, author_name="ScratchAttachV2", _session=FakeSession())
+    calls = []
+
+    def fake_put(*args, **kwargs):
+        calls.append((args, kwargs, sa.utils.requests.requests.error_handling))
+
+    monkeypatch.setattr(sa.utils.requests.requests, "put", fake_put)
+
+    project.share()
+
+    assert calls == [
+        (
+            ("https://api.scratch.mit.edu/proxy/projects/123/share/",),
+            {
+                "headers": {
+                    "x-token": "token",
+                    "accept": "application/json",
+                    "Content-Type": "application/json",
+                },
+                "cookies": {"scratchsessionsid": "session"},
+            },
+            False,
+        )
+    ]
+    assert sa.utils.requests.requests.error_handling is True
 
 
 def test_project():


### PR DESCRIPTION
Fixes #609.

## Summary
- wrap `Project.share()` in `requests.no_error_handling()` so a successful Scratch share response with a non-JSON body does not raise from the shared response checker
- add a regression test that asserts `share()` performs the PUT while response error handling is disabled, then restores the global handler flag

## Verification
- `uv run --project tests pytest tests/test_project.py::test_project_share_disables_response_json_error_handling -q`
- `uv run --project tests pytest tests/test_project.py -q`
- `uv run --with ruff ruff check scratchattach/site/project.py tests/test_project.py`
- `git diff --check`

Note: `tests/test_project.py` reports the existing credentials-dependent integration test as skipped via warning when local Scratch credentials are unavailable.

## LLM disclosure
Codex was used to inspect the issue, make the code/test change, run verification commands, and draft this PR description. The final patch was reviewed through local tests and git diff before submission.